### PR TITLE
Use lubridate and add date constraints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Suggests:
     magrittr
 RoxygenNote: 6.1.1
 Imports:
+  lubridate,
   rio,
   epitrix,
   utils,

--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -13,9 +13,6 @@
 #' @param sep The separator used between words, and defaults to the underscore
 #'   `_`.
 #'
-#' @param quiet a logical indicating if messages should be displayed to the
-#'     console (`TRUE`, default); set to `FALSE` to silence messages
-#' 
 #' @inheritParams clean_dates
 #' 
 #' @export
@@ -54,9 +51,8 @@
 #' clean_data2
 
 
-clean_data <- function(x, sep = "_", force_Date = TRUE,
-                                  guess_dates = TRUE, error_tolerance = 0.5,
-                                  quiet = FALSE) {
+clean_data <- function(x, sep = "_", force_Date = TRUE, guess_dates = TRUE, 
+                       error_tolerance = 0.5, ...) {
 
   if (!is.data.frame(x)) {
     stop("x is not a data.frame")
@@ -71,7 +67,8 @@ clean_data <- function(x, sep = "_", force_Date = TRUE,
   out <- clean_dates(out,
                      force_Date = force_Date,
                      guess_dates = guess_dates,
-                     error_tolerance = error_tolerance)
+                     error_tolerance = error_tolerance,
+                     ...)
   out
 }
 

--- a/R/clean_dates.R
+++ b/R/clean_dates.R
@@ -25,6 +25,8 @@
 #'   experimental; see [guess_dates()] for more information.
 #'
 #' @inheritParams guess_dates
+#' 
+#' @param ... further arguments passed on to [guess_dates()]
 #'
 #' @seealso  [guess_dates()] to extract dates from a messy input vector
 #' 
@@ -67,10 +69,10 @@
 #'
 #' ## clean variable names, store in new object, show results
 #' clean_data <- clean_variable_names(toy_data)
-#' clean_data <- clean_dates(clean_data)
+#' clean_data <- clean_dates(clean_data, first_date = as.Date("1950-01-01"))
 #' clean_data
 
-clean_dates <- function(x, force_Date = TRUE, guess_dates = TRUE, error_tolerance = 0.5) {
+clean_dates <- function(x, force_Date = TRUE, guess_dates = TRUE, error_tolerance = 0.5, ... ) {
   if (!is.data.frame(x)) {
     stop("x must be a data frame or linelist object")
   }
@@ -87,7 +89,7 @@ clean_dates <- function(x, force_Date = TRUE, guess_dates = TRUE, error_toleranc
 
   if (guess_dates) {
     for (i in c(are_characters, are_factors)) {
-      x[[i]] <- guess_dates(x[[i]], error_tolerance)
+      x[[i]] <- guess_dates(x[[i]], error_tolerance = error_tolerance, ...)
     }
   }
 

--- a/R/guess_dates.R
+++ b/R/guess_dates.R
@@ -47,7 +47,7 @@
 #'     issued; defaults to 0.1 (10 percent)
 #'
 #' @param first_date a Date object specifying the first valid date. Defaults to
-#'   one year before the `last_date`.
+#'   fifty years before the `last_date`.
 #'
 #' @param last_date a Date object specifying the last valid date. Defaults to the
 #'   current date. 
@@ -55,7 +55,8 @@
 #' @param orders date codes for fine-grained parsing of dates. This allows for
 #' parsing of mixed dates. If a list is supplied, that list will be used for
 #' successive tries in parsing.  This is passed on to
-#' [lubridate::parse_date_time()]
+#' [lubridate::parse_date_time()]. Default orders parse World dmy/dby dates 
+#' before US mdy/bdy dates.
 #' @param quiet a logical indicating if messages should be displayed to the
 #'     console (`TRUE`, default); set to `FALSE` to silence messages
 #'
@@ -69,7 +70,10 @@
 #' guess_dates(x, error_tolerance = 0.15, first_date = FIRST_DATE) # only 15% errors allowed
 
 guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL, 
-                        last_date = Sys.Date(), orders = NULL, quiet = TRUE) {
+                        last_date = Sys.Date(), 
+                        orders = list(world = c("dby", "dmy", "Ybd", "Ymd"), 
+                                      US = c("Omdy", "YOmd")),
+                        quiet = TRUE) {
 
   ## This function tries converting a single character string into a
   ## well-formatted date, but still returning a character. If it can't convert
@@ -79,22 +83,33 @@ guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL,
   if (is.factor(x)) {
     x <- as.character(x)
   }
-  if (is.null(first_date)) {
-    first_date <- min(seq.Date(last_date, length.out = 2, by = "-1 year"))
+  iso_8601 <- "[0-9]{4}-(0|1(?=[0-2]))[0-9]-([0-2]|3(?=[0-1]))[0-9]"
+  if (is.character(first_date) && 
+      length(first_date) == 1 && 
+      grepl(iso_8601, first_date, perl = TRUE)) {
+    first_date <- as.Date(first_date, "%Y-%m-%d")
+  }
+  if (is.character(last_date) && 
+      length(last_date) == 1 && 
+      grepl(iso_8601, last_date, perl = TRUE)) {
+    last_date <- as.Date(last_date, "%Y-%m-%d")
+  }
+  if (is.null(first_date) && inherits(last_date, "Date")) {
+    first_date <- min(seq.Date(last_date, length.out = 2, by = "-50 years"))
   } 
   if (!inherits(first_date, "Date") || !inherits(last_date, "Date")) {
-    stop("first_date and last_date must be Date objects.")
+    stop("first_date and last_date must be Date objects or characters in yyyy-mm-dd format.")
   }
   stopifnot(inherits(first_date, "Date"), inherits(last_date, "Date"))
 
-  if (is.null(orders)) {
-    orders <- list(world = c("dby", "dmy", "Ybd", "Ymd"), 
-                   US = c("Omdy", "YOmd")) 
-  } else if (!is.list(orders)) {
+  if (!is.list(orders) && is.character(orders)) {
     orders <- list(orders)
+  } 
+  if (!is.list(orders)) {
+    stop("orders must be a list of character vectors")
   }
   ## convert all entries to character strings
-  x_test       <- data.frame(lapply(orders, find_and_constrain_date, x), stringsAsFactors = FALSE)
+  x_test <- data.frame(lapply(orders, find_and_constrain_date, x), stringsAsFactors = FALSE)
   good_and_bad <- constrain_date(x_test, first_date, last_date, x)
   bad_dates    <- good_and_bad$bad_dates
   bd <- do.call("c", unname(bad_dates))

--- a/R/guess_dates.R
+++ b/R/guess_dates.R
@@ -68,7 +68,8 @@
 #' guess_dates(x, error_tolerance = 1, first_date = FIRST_DATE) # forced conversion
 #' guess_dates(x, error_tolerance = 0.15, first_date = FIRST_DATE) # only 15% errors allowed
 
-guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL, last_date = Sys.Date(), orders = NULL, quiet = TRUE) {
+guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL, 
+                        last_date = Sys.Date(), orders = NULL, quiet = TRUE) {
 
   ## This function tries converting a single character string into a
   ## well-formatted date, but still returning a character. If it can't convert
@@ -81,6 +82,9 @@ guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL, last_date =
   if (is.null(first_date)) {
     first_date <- min(seq.Date(last_date, length.out = 2, by = "-1 year"))
   } 
+  if (!inherits(first_date, "Date") || !inherits(last_date, "Date")) {
+    stop("first_date and last_date must be Date objects.")
+  }
   stopifnot(inherits(first_date, "Date"), inherits(last_date, "Date"))
 
   if (is.null(orders)) {

--- a/R/guess_dates.R
+++ b/R/guess_dates.R
@@ -46,6 +46,10 @@
 #'     proportion is exceeded, the original vector is returned, and a message is
 #'     issued; defaults to 0.1 (10 percent)
 #'
+#' @param orders this parameter specifies the valid orders for the dates. These
+#'   can be specified in unambiguous codes or letters. By default, the following
+#'   orders are used: ymd, mdy, dmy, which will capture all three combinations 
+#'   of month, day, and year. This is passed on to [lubridate::parse_date_time()]
 #' @param quiet a logical indicating if messages should be displayed to the
 #'     console (`TRUE`, default); set to `FALSE` to silence messages
 #'
@@ -53,11 +57,11 @@
 #' 
 #' x <- c("01-12-2001", "male", "female", "2018-10-18", NA, NA, "2018_10_17",
 #'       "2018 10 19", "// 24/12/1989", "this is 24/12/1989!",
-#'       "RECON NGO: 19 Sep 2018 :)")
+#'       "RECON NGO: 19 Sep 2018 :)", "6/9/11", "10/10/10")
 #' guess_dates(x, error_tolerance = 1) # forced conversion
 #' guess_dates(x, error_tolerance = 0.15) # 15 percent errors allowed 
 
-guess_dates <- function(x, error_tolerance = 0.1, quiet = TRUE) {
+guess_dates <- function(x, error_tolerance = 0.1, orders = c("Ymd", "dmy", "dBy", "mdy", "Bdy", "ymd"), quiet = TRUE) {
 
   ## This function tries converting a single character string into a
   ## well-formatted date, but still returning a character. If it can't convert
@@ -69,7 +73,7 @@ guess_dates <- function(x, error_tolerance = 0.1, quiet = TRUE) {
   }
 
   ## convert all entries to character strings
-  new_x <- vapply(x, i_extract_date_string, character(1))
+  suppressWarnings(new_x <- lubridate::parse_date_time(x, orders = orders))
 
   ## check how successful we were
   na_before <- sum(is.na(x))

--- a/man/clean_data.Rd
+++ b/man/clean_data.Rd
@@ -5,7 +5,7 @@
 \title{Clean a data.frame}
 \usage{
 clean_data(x, sep = "_", force_Date = TRUE, guess_dates = TRUE,
-  error_tolerance = 0.5, quiet = FALSE)
+  error_tolerance = 0.5, ...)
 }
 \arguments{
 \item{x}{a \code{data.frame}}
@@ -27,8 +27,7 @@ entries which cannot be identified as dates to be tolerated; if this
 proportion is exceeded, the original vector is returned, and a message is
 issued; defaults to 0.1 (10 percent)}
 
-\item{quiet}{a logical indicating if messages should be displayed to the
-console (\code{TRUE}, default); set to \code{FALSE} to silence messages}
+\item{...}{further arguments passed on to \code{\link[=guess_dates]{guess_dates()}}}
 }
 \value{
 A \code{data.frame} with standardised labels for characters and

--- a/man/clean_dates.Rd
+++ b/man/clean_dates.Rd
@@ -5,7 +5,7 @@
 \title{Handle dates data}
 \usage{
 clean_dates(x, force_Date = TRUE, guess_dates = TRUE,
-  error_tolerance = 0.5)
+  error_tolerance = 0.5, ...)
 }
 \arguments{
 \item{x}{a \code{data.frame}}
@@ -23,6 +23,8 @@ experimental; see \code{\link[=guess_dates]{guess_dates()}} for more information
 entries which cannot be identified as dates to be tolerated; if this
 proportion is exceeded, the original vector is returned, and a message is
 issued; defaults to 0.1 (10 percent)}
+
+\item{...}{further arguments passed on to \code{\link[=guess_dates]{guess_dates()}}}
 }
 \value{
 A \code{data.frame} with standardised dates.
@@ -74,7 +76,7 @@ str(toy_data)
 
 ## clean variable names, store in new object, show results
 clean_data <- clean_variable_names(toy_data)
-clean_data <- clean_dates(clean_data)
+clean_data <- clean_dates(clean_data, first_date = as.Date("1950-01-01"))
 clean_data
 }
 \seealso{

--- a/man/guess_dates.Rd
+++ b/man/guess_dates.Rd
@@ -5,7 +5,8 @@
 \title{Try and guess dates from a characters}
 \usage{
 guess_dates(x, error_tolerance = 0.1, first_date = NULL,
-  last_date = Sys.Date(), orders = NULL, quiet = TRUE)
+  last_date = Sys.Date(), orders = list(world = c("dby", "dmy", "Ybd",
+  "Ymd"), US = c("Omdy", "YOmd")), quiet = TRUE)
 }
 \arguments{
 \item{x}{a \code{character} vector or a \code{factor}}
@@ -16,7 +17,7 @@ proportion is exceeded, the original vector is returned, and a message is
 issued; defaults to 0.1 (10 percent)}
 
 \item{first_date}{a Date object specifying the first valid date. Defaults to
-one year before the \code{last_date}.}
+fifty years before the \code{last_date}.}
 
 \item{last_date}{a Date object specifying the last valid date. Defaults to the
 current date.}
@@ -24,7 +25,8 @@ current date.}
 \item{orders}{date codes for fine-grained parsing of dates. This allows for
 parsing of mixed dates. If a list is supplied, that list will be used for
 successive tries in parsing.  This is passed on to
-\code{\link[lubridate:parse_date_time]{lubridate::parse_date_time()}}}
+\code{\link[lubridate:parse_date_time]{lubridate::parse_date_time()}}. Default orders parse World dmy/dby dates
+before US mdy/bdy dates.}
 
 \item{quiet}{a logical indicating if messages should be displayed to the
 console (\code{TRUE}, default); set to \code{FALSE} to silence messages}

--- a/man/guess_dates.Rd
+++ b/man/guess_dates.Rd
@@ -4,7 +4,8 @@
 \alias{guess_dates}
 \title{Try and guess dates from a characters}
 \usage{
-guess_dates(x, error_tolerance = 0.1, quiet = TRUE)
+guess_dates(x, error_tolerance = 0.1, first_date = NULL,
+  last_date = Sys.Date(), orders = NULL, quiet = TRUE)
 }
 \arguments{
 \item{x}{a \code{character} vector or a \code{factor}}
@@ -13,6 +14,17 @@ guess_dates(x, error_tolerance = 0.1, quiet = TRUE)
 entries which cannot be identified as dates to be tolerated; if this
 proportion is exceeded, the original vector is returned, and a message is
 issued; defaults to 0.1 (10 percent)}
+
+\item{first_date}{a Date object specifying the first valid date. Defaults to
+one year before the \code{last_date}.}
+
+\item{last_date}{a Date object specifying the last valid date. Defaults to the
+current date.}
+
+\item{orders}{date codes for fine-grained parsing of dates. This allows for
+parsing of mixed dates. If a list is supplied, that list will be used for
+successive tries in parsing.  This is passed on to
+\code{\link[lubridate:parse_date_time]{lubridate::parse_date_time()}}}
 
 \item{quiet}{a logical indicating if messages should be displayed to the
 console (\code{TRUE}, default); set to \code{FALSE} to silence messages}
@@ -56,9 +68,10 @@ predict which date will be returned.
 
 x <- c("01-12-2001", "male", "female", "2018-10-18", NA, NA, "2018_10_17",
       "2018 10 19", "// 24/12/1989", "this is 24/12/1989!",
-      "RECON NGO: 19 Sep 2018 :)")
-guess_dates(x, error_tolerance = 1) # forced conversion
-guess_dates(x, error_tolerance = 0.15) # 15 percent errors allowed 
+      "RECON NGO: 19 Sep 2018 :)", "6/9/11", "10/10/10")
+FIRST_DATE <- as.Date("1969-11-11")
+guess_dates(x, error_tolerance = 1, first_date = FIRST_DATE) # forced conversion
+guess_dates(x, error_tolerance = 0.15, first_date = FIRST_DATE) # only 15\% errors allowed
 }
 \author{
 Thibaut Jombart

--- a/tests/testthat/test-get_epivars.R
+++ b/tests/testthat/test-get_epivars.R
@@ -2,7 +2,7 @@ context("get_epivars() tests")
 
 # Setup data -------------------------------------------------------
 oev <- get_dictionary()
-dfll <- clean_data(messy_data())
+dfll <- clean_data(messy_data(), first_date = as.Date("1969-4-20"))
 if (requireNamespace("tibble")) {
   dfll <- tibble::as_tibble(dfll)
 }

--- a/tests/testthat/test-guess_dates.R
+++ b/tests/testthat/test-guess_dates.R
@@ -44,3 +44,7 @@ test_that("passing a non-data frame throws an error", {
   expect_is(res$date, "Date")
 
 })
+
+test_that("passing a non-date as first_date throws an error", {
+  expect_error(guess_dates(x, first_date = "2018-01-01"), "first_date and last_date must be Date objects.")
+})

--- a/tests/testthat/test-guess_dates.R
+++ b/tests/testthat/test-guess_dates.R
@@ -22,9 +22,9 @@ test_that("American dates also work", {
 })
 
 
-test_that("The first date defaults to on year prior", {
-  last_date <- as.Date("2012-11-05")
-  first_date <- as.Date("2011-11-05")
+test_that("The first date defaults to fifty years prior", {
+  last_date <-as.Date("2012-11-05")
+  first_date <- as.Date("1962-11-05")
   er <- expected_result
   er[er < first_date | er > last_date] <- NA
   expect_warning(res <- guess_dates(x, error_tolerance = 1, last_date = last_date),
@@ -46,5 +46,8 @@ test_that("passing a non-data frame throws an error", {
 })
 
 test_that("passing a non-date as first_date throws an error", {
-  expect_error(guess_dates(x, first_date = "2018-01-01"), "first_date and last_date must be Date objects.")
+  expect_error(guess_dates(x, first_date = "18-01-01"), "first_date and last_date must be Date objects.")
+  expect_failure(expect_error(guess_dates(x, first_date = "1918-01-01"), "first_date and last_date must be Date objects."))
+  expect_error(guess_dates(x, last_date = "18-01-01"), "first_date and last_date must be Date objects.")
+  expect_failure(expect_error(guess_dates(x, last_date = "2019-01-01"), "first_date and last_date must be Date objects."))
 })

--- a/tests/testthat/test-guess_dates.R
+++ b/tests/testthat/test-guess_dates.R
@@ -1,18 +1,37 @@
 context("test guess_dates")
 
-test_that("test mixed formats", {
+x <- c("04 Feb 1982", "19 Sep 2018", "2001-01-01", "2011.12.13",
+       "ba;abb;a: 03:11:2012!", "haha... 2013-12-13..",
+       "that's a NA", "gender", "not a date", "01__Feb__1999___")
 
-  x <- c("04 Feb 1982", "19 Sep 2018", "2001-01-01", "2011.12.13",
-         "ba;abb;a: 03:11:2012!", "haha... 2013-12-13..",
-         "that's a NA", "gender", "not a date", "01__Feb__1999___")
-  
-  expected_result <- structure(c(4417, 17793, 11323, 15321, 15647, 16052,
-                                 NA, NA, NA, 10623), class = "Date")
+expected_result <- structure(c(4417, 17793, 11323, 15321, 15647, 16052,
+                               NA, NA, NA, 10623), class = "Date")
 
-  expect_equal(guess_dates(x, error_tolerance = 0.8),
+
+test_that("mixed formats work", {
+  expect_equal(guess_dates(x, error_tolerance = 0.8, first_date = as.Date("1980-01-01")),
                expected_result)
-
 })
+
+
+test_that("American dates also work", { 
+  y <- c(x, "February the 29th, 2016", "02/29/16")
+  er <- c(expected_result, as.Date(c("2016-02-29", "2016-02-29")))
+  expect_equal(guess_dates(y, error_tolerance = 0.8, first_date = as.Date("1980-01-01")),
+               er)
+})
+
+
+test_that("The first date defaults to on year prior", {
+  last_date <- as.Date("2012-11-05")
+  first_date <- as.Date("2011-11-05")
+  er <- expected_result
+  er[er < first_date | er > last_date] <- NA
+  expect_warning(res <- guess_dates(x, error_tolerance = 1, last_date = last_date),
+  "original")
+  expect_equal(res, er)
+})
+
 
 test_that("passing a non-data frame throws an error", {
 

--- a/tests/testthat/test-guess_dates.R
+++ b/tests/testthat/test-guess_dates.R
@@ -38,7 +38,7 @@ test_that("passing a non-data frame throws an error", {
   x <- structure(c(1L, 1L, 1L, 1L, 1L, 1L, 1L, 4L, 1L, 2L, 3L), .Label = c("", 
     "04-Jul-1985", "12-Sep-1987", "27-Jun-1975"), class = "factor")
   expect_error(clean_dates(x), "x must be a data frame")
-  res <- clean_dates(data.frame(date = x), error_tol = 1)
+  res <- clean_dates(data.frame(date = x), error_tol = 1, first_date = as.Date("1969-4-20"))
   expect_is(res, "data.frame")
   expect_length(res, 1)
   expect_is(res$date, "Date")

--- a/tests/testthat/test-linelist-class.R
+++ b/tests/testthat/test-linelist-class.R
@@ -1,7 +1,7 @@
 context("linelist class tests")
 
 oev <- get_dictionary()
-ll <- as_linelist(clean_data(messy_data()),
+ll <- as_linelist(clean_data(messy_data(), first_date = as.Date("1969-4-20")),
                   id = "id", 
                   date_onset = "date_of_onset",
                   case_definition = "epi_case_definition",

--- a/tests/testthat/test-list_epivars.R
+++ b/tests/testthat/test-list_epivars.R
@@ -1,6 +1,6 @@
 context("list_epivars tests")
 
-ll <- as_linelist(clean_data(messy_data()),
+ll <- as_linelist(clean_data(messy_data(), first_date = as.Date("1969-4-20")),
                   id = "id", 
                   date_onset = "date_of_onset",
                   case_definition = "epi_case_definition",

--- a/tests/testthat/test-lookup.R
+++ b/tests/testthat/test-lookup.R
@@ -2,7 +2,7 @@ context("lookup tests")
 
 # Setup data ------------------------------------------------------------------
 #
-dat <- clean_data(messy_data(5))
+dat <- clean_data(messy_data(5), first_date = as.Date("1969-4-20"))
 ll  <- as_linelist(dat,
                    id = "id", 
                    gender = "gender",

--- a/vignettes/overview.Rmd
+++ b/vignettes/overview.Rmd
@@ -57,17 +57,11 @@ package](https://cran.r-project.org/package=outbreaks).
 library('outbreaks')
 library('incidence')
 library('linelist')
-# define the important variables
-## set_dictionary(
-##   "id",
-##   "date_onset",
-##   "gender",
-##   "age",
-##   "outcome", 
-##   "date_outcome", 
-##   "date_hospitalisation" 
-##   )
 
+# define the data dictionary
+
+set_dictionary(default_dictionary())
+get_dictionary()
 # generate a template linelist with `template_linelist()`
 template_linelist(outbreaks::fluH7N9_china_2013)
 # convert the data set to a linelist and define the variables


### PR DESCRIPTION
I'm suggesting here to use lubridate's [`parse_date_time()`](https://lubridate.tidyverse.org/reference/parse_date_time.html) over the current checker for the following reasons:

1. lubridate is widely used, which means we get free tests
2. We currently have no way of parsing American-style dates
3. We can give the user the freedom to specify their own date formats

I've also included the `first_date` and `last_date` arguments so that users can constrain their dates and be given an obvious warning if any are not parsed. Merging this would fix #7. 

### Parsing dates

the new guess\_dates will be able to parse dates as the previous guess\_dates
did, with support for American dates as well:

``` r
library("linelist")
x <- c("04 Feb 1982", "19 Sep 2018", "2001-01-01", "2011.12.13",
       "ba;abb;a: 03:11:2012!", "haha... 2013-12-13..",
       "Feb 05 1982", "that's a NA", "gender", "not a date", "01__Feb__1999___")

guess_dates(x, error_tolerance = 0.8)
#>  [1] "1982-02-04" "2018-09-19" "2001-01-01" "2011-12-13" "2012-11-03" "2013-12-13" "1982-02-05"
#>  [8] NA           NA           NA           "1999-02-01"
```

It’s also possible to specify date formats to use. For example, if we know
the only non-ISO numeric date entries are from an American, then we can
specify a list of formats that will parse the dates with a decreasing priority.
Internally, this runs `lubridate::parse_date_time()` for each element of the
orders list and then chooses the first valid date.

``` r
guess_dates(x, 
            error_tolerance = 1, 
            orders = list(iso = "Ymd", world = "dby", us = c("bdy", "mdy"))
)
#>  [1] "1982-02-04" "2018-09-19" "2001-01-01" "2011-12-13" "2012-03-11" "2013-12-13" "1982-02-05"
#>  [8] NA           NA           NA           "1999-02-01"
```

The default stratification looks like this, giving world dates priority
over US dates.

``` r
orders <- list(world = c("dby", "dmy", "Ybd", "Ymd"),
               US = c("Omdy", "YOmd")) 
guess_dates(x, error_tolerance = 1, orders = orders)
#>  [1] "1982-02-04" "2018-09-19" "2001-01-01" "2011-12-13" "2012-11-03" "2013-12-13" "1982-02-05"
#>  [8] NA           NA           NA           "1999-02-01"
```

### Limiting range

By default, the `last_date` parameter is set to the current date and the
`first_date` parameter is set to `NULL`, which will indicate that the
first date is fifty years prior. It is good practice to define a first date so 
that a warning pops up if any dates are outside of the date range

``` r
res <- guess_dates(x, error_tolerance = 0.8, first_date = "1984-11-24")
#> Warning in guess_dates(x, error_tolerance = 0.8, first_date = "1984-11-24"): 
#> The following dates were not in the correct timeframe (1984-11-24 -- 2019-02-07):
#> 
#>   original     |  parsed    
#>   -----        |  -----     
#>   04 Feb 1982  |  1982-02-04
#>   NA           |  NA        
#>   04 Feb 1982  |  1982-04-19
#>   Feb 05 1982  |  1982-02-05
res
#>  [1] NA           "2018-09-19" "2001-01-01" "2011-12-13" "2012-11-03" "2013-12-13" NA          
#>  [8] NA           NA           NA           "1999-02-01"
```

<sup>Created on 2019-02-07 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>