### PR TITLE
Minor fixes to clean_variable_spelling

### DIFF
--- a/R/clean_spelling.R
+++ b/R/clean_spelling.R
@@ -11,6 +11,9 @@
 #'   is a ".default" value in the first column, then this will be used to 
 #'   change all other spellings/values to a default value in the second column.
 #'   See examples.
+#'
+#' @param quiet a `logical` indicating if warnings should be issued if no
+#'   replacement is made; if `FALSE`, these warnings will be disabled
 #' 
 #' @return a vector of the same type as `x` with mis-spelled labels cleaned. 
 #'   Note that factors will be arranged by the order presented in the data 
@@ -56,7 +59,8 @@
 #' @importFrom forcats fct_recode fct_explicit_na fct_relevel
 #' @importFrom rlang "!!!"
 
-clean_spelling <- function(x = character(), wordlist = data.frame()) {
+clean_spelling <- function(x = character(), wordlist = data.frame(),
+                           quiet = FALSE) {
 
   if (length(x) == 0 || !is.atomic(x)) {
     stop("x must be coerceable to a character")
@@ -87,14 +91,16 @@ clean_spelling <- function(x = character(), wordlist = data.frame()) {
 
   x_is_factor <- is.factor(x)
 
-  no_keys   <- !any(x %in% wordlist[[1]], na.rm = TRUE)
-  no_values <- !any(x %in% wordlist[[2]], na.rm = TRUE)
+  if (!quiet) {
+    no_keys   <- !any(x %in% wordlist[[1]], na.rm = TRUE)
+    no_values <- !any(x %in% wordlist[[2]], na.rm = TRUE)
 
-  if (no_keys && no_values) {
-    the_call <- match.call()
-    msg <- "None of the variables in %s were found in %s. Did you use the correct wordlist?" 
-    msg <- sprintf(msg, deparse(the_call[["x"]]), deparse(the_call[["wordlist"]]))
-    warning(msg)
+    if (no_keys && no_values) {
+      the_call <- match.call()
+      msg <- "None of the variables in %s were found in %s. Did you use the correct wordlist?" 
+      msg <- sprintf(msg, deparse(the_call[["x"]]), deparse(the_call[["wordlist"]]))
+      warning(msg)
+    }
   }
 
   dict <- stats::setNames(wordlist[[1]], wordlist[[2]])

--- a/R/clean_variable_spelling.R
+++ b/R/clean_variable_spelling.R
@@ -132,7 +132,6 @@ clean_variable_spelling <- function(x = data.frame(), wordlists = list(), spelli
   if (length(x) == 0 || !is.data.frame(x)) {
     stop("x must be a data frame")
   }
-
   if (is.null(classes)) {
     classes <- i_find_classes(x)
   }
@@ -215,17 +214,16 @@ clean_variable_spelling <- function(x = data.frame(), wordlists = list(), spelli
       }
     }
     # Iterate over the names of the dictionaries -----------
-    to_iterate <- names(wordlists)
+    to_iterate <- intersect(names(wordlists), names(x))
     if (has_global) {
       to_iterate <- unique(c(to_iterate, unprotected))
     }
   }
-
   # Loop over the variables and clean spelling --------------------------------
   for (i in to_iterate) {
     d <- if (ddf) wordlists else wordlists[[i]] 
     d <- if (is.null(d)) global_words else d
-    try(x[[i]] <- clean_spelling(x[[i]], d))
+    try(x[[i]] <- clean_spelling(x[[i]], d, quiet = TRUE))
   }
 
   x

--- a/man/clean_spelling.Rd
+++ b/man/clean_spelling.Rd
@@ -4,7 +4,8 @@
 \alias{clean_spelling}
 \title{Rename values in a vector based on a wordlist}
 \usage{
-clean_spelling(x = character(), wordlist = data.frame())
+clean_spelling(x = character(), wordlist = data.frame(),
+  quiet = FALSE)
 }
 \arguments{
 \item{x}{a character or factor vector}
@@ -14,6 +15,9 @@ words in the first column and replacements in the second column. If there
 is a ".default" value in the first column, then this will be used to
 change all other spellings/values to a default value in the second column.
 See examples.}
+
+\item{quiet}{a \code{logical} indicating if warnings should be issued if no
+replacement is made; if \code{FALSE}, these warnings will be disabled}
 }
 \value{
 a vector of the same type as \code{x} with mis-spelled labels cleaned.

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -141,9 +141,9 @@ test_that("A global wordlist can be implemented alongside the wordlist", {
 test_that("A global wordlist can be implemented as-is", {
 
   
-  expect_warning({
-    clean_global <- clean_data(md, wordlists = global_words)
-  }, "Did you use the correct wordlist?")
+  ## expect_warning({
+  clean_global <- clean_data(md, wordlists = global_words)
+  ## }, "Did you use the correct wordlist?")
 
   expect_true("HOSPITAL" %in% clean_global$location)
   expect_true("medical" %in% clean_global$location)

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -141,9 +141,7 @@ test_that("A global wordlist can be implemented alongside the wordlist", {
 test_that("A global wordlist can be implemented as-is", {
 
   
-  ## expect_warning({
   clean_global <- clean_data(md, wordlists = global_words)
-  ## }, "Did you use the correct wordlist?")
 
   expect_true("HOSPITAL" %in% clean_global$location)
   expect_true("medical" %in% clean_global$location)


### PR DESCRIPTION
The first try on my data issued a batch of warnings and errors which were not justified. This is an attempt to fix what I thought were bad behaviours:

- adding `quiet` argument to silence warnings in `clean_spelling`; when iterating through a large dataset chances are some variable won't need fixing and this shoud not issue a warning (clean data would too otherwise)

- avoid iterating over non-existent variables in `clean_variable_spelling`; I expected this was an unwanted behaviour, as the iterator was attempting to go over variables not in the dataset