### PR TITLE
Fix spelling na

### DIFF
--- a/R/clean_spelling.R
+++ b/R/clean_spelling.R
@@ -151,7 +151,6 @@ clean_spelling <- function(x = character(), wordlist = data.frame(),
       msg <- sprintf(msg, the_words, paste(dkeys, collapse = '", "'))
       warning(msg)
     }
-    
   }
 
   dict        <- keys

--- a/R/clean_spelling.R
+++ b/R/clean_spelling.R
@@ -139,6 +139,9 @@ clean_spelling <- function(x = character(), wordlist = data.frame(),
 
     if (any(na_present)) {
       msg <- "NA was present in the first column of %s; replacing with the character 'NA'"
+      msg <- paste(msg, 
+                   "If you want to indicate missing data, use the '.missing' keyword.", 
+                   collapse = "\n")
       msg <- sprintf(msg, the_words)
       warning(msg)
     }

--- a/R/clean_spelling.R
+++ b/R/clean_spelling.R
@@ -7,14 +7,37 @@
 #' @param x a character or factor vector
 #'
 #' @param wordlist a two-column matrix or data frame defining mis-spelled
-#'   words in the first column and replacements in the second column. If there
-#'   is a ".default" value in the first column, then this will be used to 
-#'   change all other spellings/values to a default value in the second column.
-#'   See examples.
+#'   words in the first column and replacements in the second column. There
+#'   are keywords that can be appended to the first column for cleaning missing
+#'   or default values.
 #'
 #' @param quiet a `logical` indicating if warnings should be issued if no
 #'   replacement is made; if `FALSE`, these warnings will be disabled
 #' 
+#'
+#' @details 
+#'
+#' \subsection{Keywords}{
+#'
+#' There are currently two keywords that can be placed in the first column of
+#' your wordlist:
+#'
+#'  - `.missing`: replaces any missing values
+#'  - `.default`: replaces **ALL** values that are not defined in the wordlist
+#'                and are not missing. 
+#'
+#' The `.missing` keyword is a synonym for `NA` (a _true_ missing value). This
+#' succinctly handles two potentially confusing situations:
+#'
+#'  1. You've imported your wordlist from excel and all the missing values 
+#'     (`NA`) render as `"NA"`.
+#'  2. You actually want to represent "NA" as a potential value, but you've
+#'     accidentally imported it as a missing value (`NA`)
+#'  
+#'  A warning will appear if you specify either `NA` or `"NA"` in your wordlist
+#'  without the `.missing` argument. 
+#' }
+#'
 #' @return a vector of the same type as `x` with mis-spelled labels cleaned. 
 #'   Note that factors will be arranged by the order presented in the data 
 #'   wordlist; other levels will appear afterwards.  
@@ -29,12 +52,15 @@
 #' @examples
 #'
 #' corrections <- data.frame(
-#'   bad = c("foubar", "foobr", "fubar", NA, "unknown"),
+#'   bad = c("foubar", "foobr", "fubar", "unknown", NA), 
 #'   good = c("foobar", "foobar", "foobar", "missing", "missing"),
 #'   stringsAsFactors = FALSE
 #' )
 #' corrections
-#' my_data <- c(letters[1:5], sample(corrections$bad, 10, replace = TRUE))
+#' 
+#' # create some fake data
+#' my_data <- c(letters[1:5], sample(corrections$bad[-5], 10, replace = TRUE))
+#' my_data[sample(6:15, 2)] <- NA  # with missing elements
 #'
 #' clean_spelling(my_data, corrections)
 #'

--- a/R/clean_spelling.R
+++ b/R/clean_spelling.R
@@ -26,16 +26,6 @@
 #'  - `.default`: replaces **ALL** values that are not defined in the wordlist
 #'                and are not missing. 
 #'
-#' The `.missing` keyword is a synonym for `NA` (a _true_ missing value). This
-#' succinctly handles two potentially confusing situations:
-#'
-#'  1. You've imported your wordlist from excel and all the missing values 
-#'     (`NA`) render as `"NA"`.
-#'  2. You actually want to represent "NA" as a potential value, but you've
-#'     accidentally imported it as a missing value (`NA`)
-#'  
-#'  A warning will appear if you specify either `NA` or `"NA"` in your wordlist
-#'  without the `.missing` argument. 
 #' }
 #'
 #' @return a vector of the same type as `x` with mis-spelled labels cleaned. 
@@ -52,7 +42,7 @@
 #' @examples
 #'
 #' corrections <- data.frame(
-#'   bad = c("foubar", "foobr", "fubar", "unknown", NA), 
+#'   bad = c("foubar", "foobr", "fubar", "unknown", ".missing"), 
 #'   good = c("foobar", "foobar", "foobar", "missing", "missing"),
 #'   stringsAsFactors = FALSE
 #' )
@@ -76,7 +66,7 @@
 #' # The can be used for translating survey output
 #'
 #' words <- data.frame(
-#'   option_code = c("Y", "N", "U", NA),
+#'   option_code = c("Y", "N", "U", ".missing"),
 #'   option_name = c("Yes", "No", "Unknown", "Missing"),
 #'   stringsAsFactors = FALSE
 #' )
@@ -107,29 +97,62 @@ clean_spelling <- function(x = character(), wordlist = data.frame(),
     wordlist <- as.data.frame(wordlist, stringsAsFactors = FALSE)
   }
 
-  if (!is.atomic(wordlist[[1]]) || !is.atomic(wordlist[[2]])) {
+  keys   <- wordlist[[1]]
+  values <- wordlist[[2]]
+
+  if (!is.atomic(keys) || !is.atomic(values)) {
     stop("wordlist must have two columns coerceable to a character")
   }
 
-  wordlist[[1]] <- as.character(wordlist[[1]])
-  wordlist[[2]] <- as.character(wordlist[[2]])
+  keys <- as.character(keys)
+  values <- as.character(values)
 
 
   x_is_factor <- is.factor(x)
 
+  # replace missing with "NA" if NA is present in data
+  na_present <- is.na(keys)
+  keys[na_present] <- "NA"
+
+  # replace missing keyword with NA
+  missing_kw       <- keys == ".missing" | keys == ""
+  keys[missing_kw] <- NA_character_
+
+  # removing duplicated keys
+  duplikeys <- duplicated(keys)
+  dkeys     <- keys[duplikeys]
+  keys      <- keys[!duplikeys]
+  values    <- values[!duplikeys]
+
   if (!quiet) {
-    no_keys   <- !any(x %in% wordlist[[1]], na.rm = TRUE)
-    no_values <- !any(x %in% wordlist[[2]], na.rm = TRUE)
+    the_call  <- match.call()
+    no_keys   <- !any(x %in% keys, na.rm = TRUE)
+    no_values <- !any(x %in% values, na.rm = TRUE)
+    the_x     <- deparse(the_call[["x"]])
+    the_words <- deparse(the_call[["wordlist"]])
 
     if (no_keys && no_values) {
-      the_call <- match.call()
       msg <- "None of the variables in %s were found in %s. Did you use the correct wordlist?" 
-      msg <- sprintf(msg, deparse(the_call[["x"]]), deparse(the_call[["wordlist"]]))
+      msg <- sprintf(msg, the_x, the_words)
       warning(msg)
     }
+
+    if (any(na_present)) {
+      msg <- "NA was present in the first column of %s; replacing with the character 'NA'"
+      msg <- sprintf(msg, the_words)
+      warning(msg)
+    }
+
+    if (length(dkeys) > 0) {
+      msg <- 'Duplicate keys were found in the first column of %s: "%s"\nonly the first instance will be used.'
+      msg <- sprintf(msg, the_words, paste(dkeys, collapse = '", "'))
+      warning(msg)
+    }
+    
   }
 
-  dict <- stats::setNames(wordlist[[1]], wordlist[[2]])
+  dict        <- keys
+  names(dict) <- values
   
   na_posi      <- is.na(dict)
   default_posi <- dict == ".default" 
@@ -138,8 +161,11 @@ clean_spelling <- function(x = character(), wordlist = data.frame(),
   nas     <- dict[na_posi]
   dict    <- dict[!na_posi & !default_posi]
 
+  # Making "" explicitly NA ---------------------------------------------------
+  x <- forcats::fct_recode(x, NULL = "")
+
   # Recode data with forcats --------------------------------------------------
-  suppressWarnings(x <- forcats::fct_recode(x, !!!dict))
+  suppressWarnings(x <- forcats::fct_recode(x, !!! dict))
 
   # Replace NAs if there are any ----------------------------------------------
   if (length(nas) > 0) {
@@ -153,7 +179,7 @@ clean_spelling <- function(x = character(), wordlist = data.frame(),
 
   # Make sure order is preserved if it's a factor -----------------------------
   if (x_is_factor) {
-    x <- forcats::fct_relevel(x, unique(wordlist[[2]]))
+    suppressWarnings(x <- forcats::fct_relevel(x, unique(values)))
   } else {
     x <- as.character(x)
   }

--- a/R/clean_variable_spelling.R
+++ b/R/clean_variable_spelling.R
@@ -64,10 +64,10 @@
 #' 
 #' # Set up wordlist ------------------------------------------------ 
 #'
-#' yesno  <- c("Y", "N", "U", NA)
+#' yesno  <- c("Y", "N", "U", ".missing")
 #' dyesno <- c("Yes", "No", "Unknown", "Missing")
 #'
-#' treatment_administered  <- c(0:1, NA)
+#' treatment_administered  <- c(0:1, ".missing")
 #' dtreatment_administered <- c("Yes", "No", "Missing")
 #'
 #' facility  <- c(1:10, ".default") # define a .default key
@@ -88,7 +88,7 @@
 #' # Assigning global values ----------------------------------------
 #'
 #' global_words <- data.frame(
-#'   options = c("Y", "N", "U", "unk", "oui", NA),
+#'   options = c("Y", "N", "U", "unk", "oui", ".missing"),
 #'   values  = c("yes", "no", "unknown", "unknown", "yes", "missing"),
 #'   grp     = rep(".global", 6),
 #'   orders  = rep(Inf, 6),
@@ -109,6 +109,8 @@
 #'   followup = sample(c(yesno, "unk", "oui"), 50, replace = TRUE),
 #'   stringsAsFactors = FALSE
 #' )
+#' missing_data <- dat == ".missing"
+#' dat[missing_data] <- sample(c("", NA), sum(missing_data), prob = c(0.1, 0.9), replace = TRUE)
 #'
 #' # Clean spelling based on wordlist ------------------------------ 
 #'

--- a/man/clean_spelling.Rd
+++ b/man/clean_spelling.Rd
@@ -39,23 +39,12 @@ your wordlist:
 and are not missing.
 }
 
-The \code{.missing} keyword is a synonym for \code{NA} (a \emph{true} missing value). This
-succinctly handles two potentially confusing situations:
-\enumerate{
-\item You've imported your wordlist from excel and all the missing values
-(\code{NA}) render as \code{"NA"}.
-\item You actually want to represent "NA" as a potential value, but you've
-accidentally imported it as a missing value (\code{NA})
-}
-
-A warning will appear if you specify either \code{NA} or \code{"NA"} in your wordlist
-without the \code{.missing} argument.
 }
 }
 \examples{
 
 corrections <- data.frame(
-  bad = c("foubar", "foobr", "fubar", "unknown", NA), 
+  bad = c("foubar", "foobr", "fubar", "unknown", ".missing"), 
   good = c("foobar", "foobar", "foobar", "missing", "missing"),
   stringsAsFactors = FALSE
 )
@@ -79,7 +68,7 @@ clean_spelling(letters, corrections)
 # The can be used for translating survey output
 
 words <- data.frame(
-  option_code = c("Y", "N", "U", NA),
+  option_code = c("Y", "N", "U", ".missing"),
   option_name = c("Yes", "No", "Unknown", "Missing"),
   stringsAsFactors = FALSE
 )

--- a/man/clean_spelling.Rd
+++ b/man/clean_spelling.Rd
@@ -11,10 +11,9 @@ clean_spelling(x = character(), wordlist = data.frame(),
 \item{x}{a character or factor vector}
 
 \item{wordlist}{a two-column matrix or data frame defining mis-spelled
-words in the first column and replacements in the second column. If there
-is a ".default" value in the first column, then this will be used to
-change all other spellings/values to a default value in the second column.
-See examples.}
+words in the first column and replacements in the second column. There
+are keywords that can be appended to the first column for cleaning missing
+or default values.}
 
 \item{quiet}{a \code{logical} indicating if warnings should be issued if no
 replacement is made; if \code{FALSE}, these warnings will be disabled}
@@ -29,15 +28,42 @@ This function provides an interface for \code{\link[forcats:fct_recode]{forcats:
 \code{\link[forcats:fct_explicit_na]{forcats::fct_explicit_na()}}, and \code{\link[forcats:fct_relevel]{forcats::fct_relevel()}} in such a way that
 a data wordlist can be imported from a data frame.
 }
+\details{
+\subsection{Keywords}{
+
+There are currently two keywords that can be placed in the first column of
+your wordlist:
+\itemize{
+\item \code{.missing}: replaces any missing values
+\item \code{.default}: replaces \strong{ALL} values that are not defined in the wordlist
+and are not missing.
+}
+
+The \code{.missing} keyword is a synonym for \code{NA} (a \emph{true} missing value). This
+succinctly handles two potentially confusing situations:
+\enumerate{
+\item You've imported your wordlist from excel and all the missing values
+(\code{NA}) render as \code{"NA"}.
+\item You actually want to represent "NA" as a potential value, but you've
+accidentally imported it as a missing value (\code{NA})
+}
+
+A warning will appear if you specify either \code{NA} or \code{"NA"} in your wordlist
+without the \code{.missing} argument.
+}
+}
 \examples{
 
 corrections <- data.frame(
-  bad = c("foubar", "foobr", "fubar", NA, "unknown"),
+  bad = c("foubar", "foobr", "fubar", "unknown", NA), 
   good = c("foobar", "foobar", "foobar", "missing", "missing"),
   stringsAsFactors = FALSE
 )
 corrections
-my_data <- c(letters[1:5], sample(corrections$bad, 10, replace = TRUE))
+
+# create some fake data
+my_data <- c(letters[1:5], sample(corrections$bad[-5], 10, replace = TRUE))
+my_data[sample(6:15, 2)] <- NA  # with missing elements
 
 clean_spelling(my_data, corrections)
 

--- a/man/clean_variable_spelling.Rd
+++ b/man/clean_variable_spelling.Rd
@@ -71,10 +71,10 @@ numeric and Date columns from conversion to character.
 
 # Set up wordlist ------------------------------------------------ 
 
-yesno  <- c("Y", "N", "U", NA)
+yesno  <- c("Y", "N", "U", ".missing")
 dyesno <- c("Yes", "No", "Unknown", "Missing")
 
-treatment_administered  <- c(0:1, NA)
+treatment_administered  <- c(0:1, ".missing")
 dtreatment_administered <- c("Yes", "No", "Missing")
 
 facility  <- c(1:10, ".default") # define a .default key
@@ -95,7 +95,7 @@ wordlist <- data.frame(
 # Assigning global values ----------------------------------------
 
 global_words <- data.frame(
-  options = c("Y", "N", "U", "unk", "oui", NA),
+  options = c("Y", "N", "U", "unk", "oui", ".missing"),
   values  = c("yes", "no", "unknown", "unknown", "yes", "missing"),
   grp     = rep(".global", 6),
   orders  = rep(Inf, 6),
@@ -116,6 +116,8 @@ dat <- data.frame(
   followup = sample(c(yesno, "unk", "oui"), 50, replace = TRUE),
   stringsAsFactors = FALSE
 )
+missing_data <- dat == ".missing"
+dat[missing_data] <- sample(c("", NA), sum(missing_data), prob = c(0.1, 0.9), replace = TRUE)
 
 # Clean spelling based on wordlist ------------------------------ 
 

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -119,9 +119,7 @@ test_that("A global wordlist can be implemented alongside the wordlist", {
 
   wl <- rbind(wordlist, global_words, stringsAsFactors = FALSE)
 
-  expect_warning({
-    clean_global <- clean_data(md, wordlists = wl)
-  }, "HOSPITAL") # warning from forcats
+  clean_global <- clean_data(md, wordlists = wl)
 
   expect_is(clean_global$location, "factor")
 

--- a/tests/testthat/test-clean_spelling.R
+++ b/tests/testthat/test-clean_spelling.R
@@ -2,13 +2,13 @@ context("clean spelling tests")
 
 
 corrections <- data.frame(
-  bad = c("foubar", "foobr", "fubar", NA, "unknown"),
+  bad = c("foubar", "foobr", "fubar", ".missing", "unknown"),
   good = c("foobar", "foobar", "foobar", "missing", "missing"),
   stringsAsFactors = FALSE
 )
 
-my_data <- c(letters[1:5], "foubar", "foobr", "fubar", NA, "unknown", "fumar")
-cleaned_data <- c(letters[1:5], "foobar", "foobar", "foobar", "missing", "missing", "fumar")
+my_data <- c(letters[1:5], "foubar", "foobr", "fubar", NA, "", "unknown", "fumar")
+cleaned_data <- c(letters[1:5], "foobar", "foobar", "foobar", "missing", "missing", "missing", "fumar")
 
 test_that("clean_spelling throws an error with no data or a data frame", {
 

--- a/tests/testthat/test-clean_spelling.R
+++ b/tests/testthat/test-clean_spelling.R
@@ -44,10 +44,27 @@ test_that("clean_spelling will clean everything defined in the wordlist", {
 })
 
 
-
 test_that("clean_spelling will work with a matrix", {
 
   expect_identical(clean_spelling(my_data, as.matrix(corrections)), cleaned_data) 
+
+})
+
+test_that("clean_spelling will throw a warning if there is a missing value", {
+
+  corrections2 <- corrections
+  missme <- corrections[[1]] == ".missing"
+  corrections2[[1]][missme] <- NA
+  expect_warning(clean_spelling(my_data, corrections2),
+                 "If you want to indicate missing data, use the '.missing' keyword")
+
+})
+
+test_that("clean_spelling will throw a warning if there are duplicated keys", {
+
+  corrections2 <- rbind(corrections, corrections[1:2, ])
+  expect_warning(clean_spelling(my_data, corrections2),
+                 "Duplicate keys were found.+.foubar., .foobr.[^,]")
 
 })
 

--- a/tests/testthat/test-clean_variable_spelling.R
+++ b/tests/testthat/test-clean_variable_spelling.R
@@ -2,7 +2,7 @@ context("clean_variable_spelling() tests")
 
 
 corrections <- data.frame(
-  bad = c("foubar", "foobr", "fubar", NA, "unknown", "Yes", "Y", "No", "N", NA),
+  bad = c("foubar", "foobr", "fubar", ".missing", "unknown", "Yes", "Y", "No", "N", ".missing"),
   good = c("foobar", "foobar", "foobar", "missing", "missing", "yes", "yes", "no", "no", "missing"),
   column = c(rep("raboof", 5), rep("treatment", 5)),
   orders = c(1:5, 5:1),
@@ -12,7 +12,7 @@ corrections <- data.frame(
 clist <- split(corrections, corrections$column)
 
 my_data_frame <- data.frame(
-   raboof    = c(letters[1:5], "foubar", "foobr", "fubar", NA, "unknown", "fumar"),
+   raboof    = c(letters[1:5], "foubar", "foobr", "fubar", "", "unknown", "fumar"),
    treatment = c(letters[5:1], "Y", "Yes", "N", NA, "No", "yes"),
    region    = state.name[1:11]
 )


### PR DESCRIPTION
I've added support for a `.missing` or blank keyword to represent either `""` or `NA` values. This has the following behavior for the wordlist

 - anything in the keys that is `NA` (missing) will be converted to "NA" (character) and throw a warning. This is to avoid the common situation where "NA" is imported as missing data. 
 - duplicated keys will only have the first key represented. 

For the data, there is one behavioral change:  blank entries are automatically converted to `NA`. 

It goes without saying that this merge will fix #44 