### PR TITLE
clean_variable_spelling: Use global first and then parse others later

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: linelist
 Title: Tools to Import and Tidy Case Linelist Data
-Version: 0.8.1.9000
+Version: 0.8.2.9000
 Authors@R: c(person("Thibaut", "Jombart", email = "thibautjombart@gmail.com", role = c("aut", "cre")),
     person("Zhian N.", "Kamvar", email = "zkamvar@gmail.com", role = c("aut")))
 Description: A collection of wrappers for importing case linelist data from usual formats, and tools for cleaning data, detecting dates, and storing meta-information on the content of the resulting \code{data.frame}.  

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# linelist 0.8.2.9000
+
+* `clean_variable_spelling()` will now run global variables before processing
+  named variables instead of in tandem. This allows the user to define
+  misspellings in the `.global` variable.
+  See https://github.com/reconhub/linelist/issues/51 for details.
+
 # linelist 0.8.1.9000
 
 * `clean_spelling()` will no longer throw a warning if there is no value for

--- a/R/clean_data.R
+++ b/R/clean_data.R
@@ -15,6 +15,14 @@
 #'
 #' @return A `data.frame` with standardised labels for characters and
 #'   factors.
+#'
+#' @note \subsection{Creating your wordlist}{
+#'  When creating the wordlist for `clean_variable_spelling()`, it's important
+#'  to remember that the data will first be cleaned with 
+#'  `clean_variable_labels()`, which will remove any capitalisation, accents,
+#'  and replace all punctuation and spaces with "_". 
+#'
+#' }
 #' 
 #' @seealso This function wraps three other functions: 
 #' [clean_variable_names()] - to handle variable names, 

--- a/R/clean_variable_spelling.R
+++ b/R/clean_variable_spelling.R
@@ -34,13 +34,13 @@
 #' \subsection{Global wordlists}{
 #' 
 #' A global wordlist is a set of definitions applied to all valid columns of `x`
-#' indiscriminantly. When a global dictioary is used, you might see several
-#' warnings appear because some variables were not found in the data.
+#' indiscriminantly.
 #'
 #'  - **.global spelling_var**: If you want to apply a set of definitions to all
 #'     valid columns in addition to specified columns, then you can include a
 #'     `.global` group in the `spelling_var` column of your `wordlists` data
-#'     frame. *NOTE: specific variable definitions will override global
+#'     frame. This is useful for setting up a dictionary of common spelling 
+#'     errors. *NOTE: specific variable definitions will override global
 #'     defintions.* For example: if you have a column for cardinal directions
 #'     and a definiton for `N = North`, then the global variable `N = no` will
 #'     not override that. See Example.
@@ -67,7 +67,7 @@
 #' 
 #' # Set up wordlist ------------------------------------------------ 
 #'
-#' yesno  <- c("Y", "N", "U", ".missing")
+#' yesno  <- c("y", "n", "u", ".missing")
 #' dyesno <- c("Yes", "No", "Unknown", "Missing")
 #'
 #' treatment_administered  <- c(0:1, ".missing")
@@ -91,7 +91,7 @@
 #' # Assigning global values ----------------------------------------
 #'
 #' global_words <- data.frame(
-#'   options = c("Y", "N", "U", "unk", "oui", ".missing"),
+#'   options = c("y", "n", "u", "unk", "oui", ".missing"),
 #'   values  = c("yes", "no", "unknown", "unknown", "yes", "missing"),
 #'   grp     = rep(".global", 6),
 #'   orders  = rep(Inf, 6),
@@ -187,8 +187,8 @@ clean_variable_spelling <- function(x = data.frame(), wordlists = list(), spelli
     }
   }
 
-  one_big_dictionary            <- is.data.frame(wordlists)
-  exists_sort_by <- !is.null(sort_by)
+  one_big_dictionary <- is.data.frame(wordlists)
+  exists_sort_by     <- !is.null(sort_by)
 
   if (one_big_dictionary) {
     # If there is one big dictionary ------------------------------------
@@ -217,6 +217,20 @@ clean_variable_spelling <- function(x = data.frame(), wordlists = list(), spelli
     }
   }
 
+  # check if there is a ".default" value in the global dictionary
+  global_with_default <- one_big_dictionary && 
+    any(wordlists[[1]] == ".default") || 
+    (
+     !one_big_dictionary && 
+     has_global && 
+     any(global_words[[1]] == ".default")
+    )
+
+  if (global_with_default) {
+  
+    stop("the .default keyword cannot be used with .global")
+  
+  }
   # Prepare warning/error labels ---------------------------------------------
   warns <- vector(mode = "list", length = length(to_iterate)) -> errs
   iter_print <- gsub(" ", "_", format(to_iterate))

--- a/man/clean_data.Rd
+++ b/man/clean_data.Rd
@@ -65,6 +65,15 @@ by standardising variable names, labels used categorical variables
 intelligent date search can be used on character strings to extract dates
 from various formats mixed with other text. See details for more information.
 }
+\note{
+\subsection{Creating your wordlist}{
+When creating the wordlist for \code{clean_variable_spelling()}, it's important
+to remember that the data will first be cleaned with
+\code{clean_variable_labels()}, which will remove any capitalisation, accents,
+and replace all punctuation and spaces with "_".
+
+}
+}
 \examples{
 
 ## make toy data

--- a/man/clean_variable_spelling.Rd
+++ b/man/clean_variable_spelling.Rd
@@ -49,13 +49,13 @@ well.
 \subsection{Global wordlists}{
 
 A global wordlist is a set of definitions applied to all valid columns of \code{x}
-indiscriminantly. When a global dictioary is used, you might see several
-warnings appear because some variables were not found in the data.
+indiscriminantly.
 \itemize{
 \item \strong{.global spelling_var}: If you want to apply a set of definitions to all
 valid columns in addition to specified columns, then you can include a
 \code{.global} group in the \code{spelling_var} column of your \code{wordlists} data
-frame. \emph{NOTE: specific variable definitions will override global
+frame. This is useful for setting up a dictionary of common spelling
+errors. \emph{NOTE: specific variable definitions will override global
 defintions.} For example: if you have a column for cardinal directions
 and a definiton for \code{N = North}, then the global variable \code{N = no} will
 not override that. See Example.
@@ -74,7 +74,7 @@ numeric and Date columns from conversion to character.
 
 # Set up wordlist ------------------------------------------------ 
 
-yesno  <- c("Y", "N", "U", ".missing")
+yesno  <- c("y", "n", "u", ".missing")
 dyesno <- c("Yes", "No", "Unknown", "Missing")
 
 treatment_administered  <- c(0:1, ".missing")
@@ -98,7 +98,7 @@ wordlist <- data.frame(
 # Assigning global values ----------------------------------------
 
 global_words <- data.frame(
-  options = c("Y", "N", "U", "unk", "oui", ".missing"),
+  options = c("y", "n", "u", "unk", "oui", ".missing"),
   values  = c("yes", "no", "unknown", "unknown", "yes", "missing"),
   grp     = rep(".global", 6),
   orders  = rep(Inf, 6),

--- a/man/compare_data.Rd
+++ b/man/compare_data.Rd
@@ -38,6 +38,10 @@ compared}
 \item{use_values}{a \code{logical} indicating if values of matching
 categorical variables should be compared}
 }
+\value{
+an object of class \code{data_comparison}. This is a named list for
+each test
+}
 \description{
 This function extracts the structures of two \code{data.frames} and compares them,
 issuing a series of diagnostics.

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -119,7 +119,10 @@ test_that("A global wordlist can be implemented alongside the wordlist", {
 
   wl <- rbind(wordlist, global_words, stringsAsFactors = FALSE)
 
-  clean_global <- clean_data(md, wordlists = wl)
+
+  expect_warning({
+    clean_global <- clean_data(md, wordlists = wl, warn = TRUE)
+  }, "epi_case_definition__:")
 
   expect_is(clean_global$location, "factor")
 
@@ -139,7 +142,14 @@ test_that("A global wordlist can be implemented alongside the wordlist", {
 test_that("A global wordlist can be implemented as-is", {
 
   
-  clean_global <- clean_data(md, wordlists = global_words)
+  expect_warning({
+    clean_global <- clean_data(md, 
+                               wordlists = global_words, 
+                               sort_by = "orders", 
+                               spelling_vars = NULL 
+                              )
+  }, "Using wordlist globally across all character/factor columns.")
+
 
   expect_true("HOSPITAL" %in% clean_global$location)
   expect_true("medical" %in% clean_global$location)
@@ -160,8 +170,14 @@ test_that("A global wordlist with a '.default' value would throw an error", {
 
 test_that("clean_variables and clean_data will return the same thing if no dates", {
 
-  cdcd <- clean_data(md, wordlists = wordlist, spelling_vars = "var_shortname", guess_dates = FALSE, force_Date = FALSE)
-  cdcv <- clean_variables(clean_variable_names(md), wordlists = wordlist, spelling_vars = "var_shortname")
+  cdcd <- clean_data(md, 
+                     wordlists = wordlist, 
+                     spelling_vars = "var_shortname", 
+                     guess_dates = FALSE, 
+                     force_Date = FALSE)
+  cdcv <- clean_variables(clean_variable_names(md), 
+                          wordlists = wordlist, 
+                          spelling_vars = "var_shortname")
   expect_identical(cdcd, cdcv)
 })
 

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -20,17 +20,17 @@ md$location <- factor(messy_locations)
 
 # add a wordlist
 wordlist <- data.frame(
-  from  = c("hopsital", "hopital",  "medical", "feild"),
-  to    = c("hospital", "hospital", "clinic",  "field"),
-  var_shortname = rep("location", 4),
-  orders = 1:4,
+  from  = c("hopsital", "hopital",  "medical", "feild", "not_a_case"),
+  to    = c("hospital", "hospital", "clinic",  "field", "not a case"),
+  var_shortname = c(rep("location", 4), "epi_case_definition"),
+  orders = c(1:4, 1),
   stringsAsFactors = FALSE
 )
 
 # define a global wordlist to check for things that change and things that don't
 global_words <- data.frame(
-  from = c("not_a_case", "female", "male", "hopital"),
-  to  = c("not a case", "feminine", "masculine", "HOSPITAL"),
+  from = c("female", "male", "hopital"),
+  to  = c("feminine", "masculine", "HOSPITAL"),
   var_shortname     = ".global",
   orders = Inf,
   stringsAsFactors = FALSE
@@ -146,6 +146,17 @@ test_that("A global wordlist can be implemented as-is", {
   expect_true("hopsital" %in% clean_global$location)
 
 })
+
+test_that("A global wordlist with a '.default' value would throw an error", {
+
+  gw <- rbind(global_words, c(".default", "NOOOOO", ".global", "Inf"))
+  expect_error(clean_data(md, wordlists = gw), "the .default keyword cannot be used with .global")
+
+  wl <- rbind(wordlist, gw, stringsAsFactors = FALSE)
+  expect_error(clean_data(md, wordlists = gw), "the .default keyword cannot be used with .global")
+  
+})
+
 
 test_that("clean_variables and clean_data will return the same thing if no dates", {
 


### PR DESCRIPTION
This will fix #51

The changes here:

 - for `clean_variable_spelling()`, if there is a `.global` section, it will be run first instead of in concert with the defined variables. This allows `.global` to act as a spell checker and specific variables to be a well-defined dictionary. (e.g. global can check for "y", "yy", "ys", "oui", "si", etc. to mean "yes" and a specific variable can decide what a "yes" should actually mean).
 - an error will be thrown if `.global` also has a `.default` keyword. 