### PR TITLE
update compare_data; add test; bump version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: linelist
 Title: Tools to Import and Tidy Case Linelist Data
-Version: 0.8.2.9000
+Version: 0.8.3.9000
 Authors@R: c(person("Thibaut", "Jombart", email = "thibautjombart@gmail.com", role = c("aut", "cre")),
     person("Zhian N.", "Kamvar", email = "zkamvar@gmail.com", role = c("aut")))
 Description: A collection of wrappers for importing case linelist data from usual formats, and tools for cleaning data, detecting dates, and storing meta-information on the content of the resulting \code{data.frame}.  

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# linelist 0.8.3.9000
+
+* `compare_data()` now returns list of variable classes instead of TRUE if the
+  classes match. (See #53 for details).
+
 # linelist 0.8.2.9000
 
 * `clean_variable_spelling()` will now run global variables before processing

--- a/R/compare_data.R
+++ b/R/compare_data.R
@@ -232,7 +232,7 @@ compare_classes <- function(ref, x) {
                     new_class = x_classes[i]
                     )
     } else {
-      out[[i]] <- TRUE
+      out[[i]] <- ref_classes[i] 
     }
 
   }

--- a/R/print.data_comparison.R
+++ b/R/print.data_comparison.R
@@ -83,13 +83,13 @@ print.data_comparison <- function(x, ...) {
       for (i in seq_along(x$classes)) {
         e <- x$classes[[i]]
         current_variable <- names(x$classes)[i]
-        if (isTRUE(e)) {
+        if (length(e) == 1) {
           cat(
               crayon::green(
                             sprintf(
                                     "`%s`: same class (%s) \n",
                                     current_variable,
-                                    class(e))
+                                    e)
                             )
               )
         } else {
@@ -149,7 +149,7 @@ print.data_comparison <- function(x, ...) {
           cat(
               crayon::italic(
                              sprintf(
-                                     "\n  * `%s`, values common to both datesets:\n",
+                                     "\n  * `%s`, values common to both datasets:\n",
                                      current_variable))
               )
           print(e$common)

--- a/tests/testthat/test-compare_data.R
+++ b/tests/testthat/test-compare_data.R
@@ -20,7 +20,7 @@ test_that("Same content in different order will say so", {
   expect_is(res, "data_comparison")
   expect_identical(res$names, list(different_order = TRUE))
   expect_identical(names(res$classes), names(iris))
-  expect_true(all(unlist(res$classes)))
+  expect_identical(vapply(res$classes, "[[", character(1), 1), i_find_classes(iris))
   expect_true(res$values)
   expect_true(res$dim)
   


### PR DESCRIPTION
This will fix #53


``` r
linelist::compare_data(iris, iris[-1])
#> 
#>  /// Comparisons of data content // 
#> 
#> 
#>  // Comparison of dimensions /
#>   * different numbers of columns: ref has 5, new data has 4
#> 
#> 
#>  // Comparison of variable names /
#> 
#>   * variables missing in the new data:
#> [1] "Sepal.Length"
#> 
#>   * variables common to both datesets:
#> [1] "Sepal.Width"  "Petal.Length" "Petal.Width"  "Species"     
#> 
#> 
#>  // Comparison of variable classes /
#> `Sepal.Width`: same class (numeric) 
#> `Petal.Length`: same class (numeric) 
#> `Petal.Width`: same class (numeric) 
#> `Species`: same class (factor) 
#> 
#> 
#>  // Comparison of values in categorical variables /
#> 
#> Same values for categorical variables
```

<sup>Created on 2019-03-08 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
