### PR TITLE
clean_spelling(): add ".na" keyword to values

### DIFF
--- a/man/clean_spelling.Rd
+++ b/man/clean_spelling.Rd
@@ -10,10 +10,10 @@ clean_spelling(x = character(), wordlist = data.frame(),
 \arguments{
 \item{x}{a character or factor vector}
 
-\item{wordlist}{a two-column matrix or data frame defining mis-spelled
-words in the first column and replacements in the second column. There
-are keywords that can be appended to the first column for cleaning missing
-or default values.}
+\item{wordlist}{a two-column matrix or data frame defining mis-spelled words
+in the first column (keys) and replacements (values) in the second column.
+There are keywords that can be appended to the first column for addressing
+default values and missing data.}
 
 \item{quiet}{a \code{logical} indicating if warnings should be issued if no
 replacement is made; if \code{FALSE}, these warnings will be disabled}
@@ -34,23 +34,42 @@ This function provides an interface for \code{\link[forcats:fct_recode]{forcats:
 a data wordlist can be imported from a data frame.
 }
 \details{
-\subsection{Keywords}{
+\subsection{Keys (first column)}{
 
-There are currently two keywords that can be placed in the first column of
-your wordlist:
+The first column of the wordlist will contain the keys that you want to
+match in your current data set. These are expected to match exactly with
+the exception of two reserved keywords that both start with a full stop:
 \itemize{
-\item \code{.missing}: replaces any missing values
+\item \code{.missing}: replaces any missing values (see NOTE)
 \item \code{.default}: replaces \strong{ALL} values that are not defined in the wordlist
 and are not missing.
 }
 
 }
+\subsection{Values (second column)}{
+
+The values will replace their respective keys exactly as they are presented.
+
+There is currently one recognised keyword that can be placed in the second
+column of your wordlist:
+\itemize{
+\item \code{.na}: Replace keys with missing data. When used in combination with the
+\code{.missing} keyword (in column 1), it can allow you to differentiate
+between explicit and implicit missing data.
+}
+
+}
+}
+\note{
+If there are any missing values in the first column (keys), then they
+are automatically converted to the character "NA" with a warning. If you want
+to target missing data with your wordlist, use the \code{.missing} keyword.
 }
 \examples{
 
 corrections <- data.frame(
   bad = c("foubar", "foobr", "fubar", "unknown", ".missing"), 
-  good = c("foobar", "foobar", "foobar", "missing", "missing"),
+  good = c("foobar", "foobar", "foobar", ".na", "missing"),
   stringsAsFactors = FALSE
 )
 corrections
@@ -79,7 +98,7 @@ clean_spelling(letters, corrections)
 
 words <- data.frame(
   option_code = c("Y", "N", "U", ".missing"),
-  option_name = c("Yes", "No", "Unknown", "Missing"),
+  option_name = c("Yes", "No", ".na", "Missing"),
   stringsAsFactors = FALSE
 )
 clean_spelling(c("Y", "Y", NA, "N", "U", "U", "N"), words)


### PR DESCRIPTION
This will fix #55. I've added a line that will replace any ".na" values with true `NA`s. It's literally one line of extra code (but a lot more documentation :sweat_smile:). @ffinger, does this method work for you?



Todo:

 - [ ] update documentation for `clean_variable_spelling()`
 - [ ] update examples
 - [ ] update tests