### PR TITLE
Speedup guess dates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: linelist
 Title: Tools to Import and Tidy Case Linelist Data
-Version: 0.0.32.9000
+Version: 0.0.33.9000
 Authors@R: c(person("Thibaut", "Jombart", email = "thibautjombart@gmail.com", role = c("aut", "cre")),
     person("Zhian N.", "Kamvar", email = "zkamvar@gmail.com", role = c("aut")))
 Description: A collection of wrappers for importing case linelist data from usual formats, and tools for cleaning data, detecting dates, and storing meta-information on the content of the resulting data frame.  

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * `guess_dates()` now processes at double the speed of the previous version.
 * `guess_dates()` will now properly constrain date vectors to the start and end
   dates. 
+* `guess_dates()` correctly parses dates represented as integers from excel
+  (#73).
 
 # linelist 0.0.32.9000
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # linelist 0.0.33.9000
 
 * `guess_dates()` now processes at double the speed of the previous version.
-  `guess_dates()` will now properly constrain date vectors to the start and end
+* `guess_dates()` will now properly constrain date vectors to the start and end
   dates. 
 
 # linelist 0.0.32.9000

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# linelist 0.0.33.9000
+
+* `guess_dates()` now processes at double the speed of the previous version.
+  `guess_dates()` will now properly constrain date vectors to the start and end
+  dates. 
+
 # linelist 0.0.32.9000
 
 * `print.data_comparison()` now sets `diff_only = TRUE` by default (#71)

--- a/R/guess_dates.R
+++ b/R/guess_dates.R
@@ -199,7 +199,7 @@ guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL,
   # If the input is a date already: no guessing needed!
   if (inherits(x, c("Date", "POSIXt", "aweek"))) {
     x <- as.Date(x)
-    x <- x[x >= first_date | x <= last_date]
+    x[x < first_date | x > last_date] <- as.Date(NA_character_)
     return(x)
   }
 

--- a/R/guess_dates.R
+++ b/R/guess_dates.R
@@ -128,8 +128,8 @@
 #' # guess_dates can handle messy dates and tolerate missing data
 #' 
 #' x <- c("01-12-2001", "male", "female", "2018-10-18", NA, NA, "2018_10_17",
-#'       "43387", "2018 10 19", "// 24/12/1989", "this is 24/12/1989!",
-#'       "RECON NGO: 19 Sep 2018 :)", "6/9/11", "10/10/10")
+#'        "43391", "2018 10 19", "// 24/12/1989", "this is 24/12/1989!",
+#'        "RECON NGO: 19 Sep 2018 :)", "6/9/11", "10/10/10")
 #'
 #' guess_dates(x, error_tolerance = 1) # forced conversion
 #' 
@@ -399,7 +399,7 @@ rescue_lubridate_failures <- function(date_a_frame, original_dates, mxl = TRUE, 
 
   # Use the excel guesser
   if (sum(go_exel)) {
-    origin <- if (mxl) as.Date("1900-01-01") else as.Date("1904-01-01")
+    origin <- if (mxl) as.Date("1899-12-30") else as.Date("1904-01-01")
     tmpxl  <- as.Date(o_num[go_exel], origin = origin)
     date_a_frame[[1]][go_exel] <- constrain_dates(tmpxl, original_dates[go_exel], dmin, dmax, baddies)
   }

--- a/R/guess_dates.R
+++ b/R/guess_dates.R
@@ -165,7 +165,6 @@ guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL,
   ## $US_formats
   ## [1] "Omdy" "YOmd"
   ## 
-  ## This returns a data frame of potential dates that is then 
 
 
   # Process first and last dates -----------------------------------------------
@@ -226,21 +225,38 @@ guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL,
   
   # Guess dates ----------------------------------------------------------------
 
-  ## convert all entries to character strings
-  x_test <- data.frame(lapply(orders, find_lubridate, x), stringsAsFactors = FALSE)
+  # create a new environment for the out of bounds dates to live
+  baddies <- new.env()
 
-  ## constrain dates to the timeframe
-  first_constraint <- constrain_date(x_test, first_date, last_date, x)
+  # creat output data frame for dates
+  res        <- list(rep(as.Date(NA_character_), length(x)))
+  res        <- rep(res, length(orders))
+  names(res) <- names(orders)
+
+  # loop over each set of lubridate orders and find the dates
+  for (i in seq_along(orders)) {
+
+    # only test the dates if the previous run wasn't successful or the user doesn't want to
+    # keep <- if (!fast || i == 1) TRUE else keep & is.na(res[[i - 1]])
+
+    res[[i]] <- find_and_constrain_date(x, orders[[i]], keep = TRUE, first_date, last_date, baddies)
+
+  }
 
   ## if lubridate fails to do the job, then we should use thibaut's parser.  
-  x_rescued    <- rescue_lubridate_failures(first_constraint$good_dates, x, mxl = modern_excel)
-  good_and_bad <- constrain_date(x_rescued, first_date, last_date, x)
+  x_rescued <- rescue_lubridate_failures(data.frame(res),
+                                         original_dates = x, 
+                                         mxl = modern_excel,
+                                         dmin = first_date,
+                                         dmax = last_date,
+                                         baddies = baddies
+                                         )
 
   # process dates that were not parsed -----------------------------------------
-  bad_dates    <- c(first_constraint$bad_dates, good_and_bad$bad_dates)
-  bd           <- do.call("c", unname(bad_dates))
+
+  bd <- as.list(baddies) # convert the environment to a list
   
-  if (!all(is.na(bd))) {
+  if (length(bd) > 0) {
     bd     <- utils::stack(bd)     # make a data frame with ind and values
     bd$ind <- as.character(bd$ind) # convert ind to char
     bd     <- unique(bd)           # only consider unique values
@@ -259,7 +275,8 @@ guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL,
   }
   
   # Select the correct dates and test if we were successful --------------------
-  new_x           <- choose_first_good_date(good_and_bad$good_dates)
+
+  new_x           <- choose_first_good_date(x_rescued)
   na_before       <- sum(is.na(x))
   na_after        <- sum(is.na(new_x))
   prop_successful <- (length(x) - na_after) / (length(x) - na_before)
@@ -272,81 +289,120 @@ guess_dates <- function(x, error_tolerance = 0.1, first_date = NULL,
   }
 }
 
-
-#' lappy-friendly wrapper of parse_date_time
+#' Finds dates with lubridate and constrains them to a date range
 #'
-#' @param orders, a vector of orders to consider
-#' @param x the data
-#' @keywords internal
+#' This takes a character vector and returns a vector of successfully translated
+#' dates within the specified range.
+#'
+#' It will also have the side-effect of populating an environment of bad dates
+#' that can be used for warning the user
+#'
 #' @noRd
-find_lubridate <- function(orders = NULL, x) {
-  suppressWarnings(as.Date(lubridate::parse_date_time(x, orders = orders)))
+#' @param x a character vector that can be converted to dates
+#' @param orders a vector of lubridate orders to consider
+#' @param keep a logical vector indicating the dates to test from `x`
+#' @param dmin the minimum dates
+#' @param dmax the maximum dates
+#' @param baddies an environment that will act as a list of bad dates. 
+#' @keywords internal
+find_and_constrain_date <- function(x, orders = NULL, keep = TRUE, dmin, dmax, baddies) {
+
+  # create an empty date vector
+  res <- rep(as.Date(NA_character_), length(x))
+  
+  # guess at only the subset of dates
+  suppressWarnings(res[keep] <- as.Date(lubridate::parse_date_time(x[keep], orders = orders)))
+  
+  res[keep] <- constrain_dates(res[keep], x[keep], dmin, dmax, baddies)
+  res
+
 }
+
 
 #' Trim dates outside of the defined boundaries
 #'
+#' @noRd
 #' @param date_a_frame a data frame where each column represents several
 #'   different parsings of the original date vector.
 #' @param dmin the minimum date
 #' @param dmax the maximum date
 #' @param original_dates the vector of original dates (to be collected for errors)
 #' @keywords internal
-#' @noRd
-constrain_date <- function(date_a_frame, dmin, dmax, original_dates = NULL) {
-  if (!is.null(original_dates)) {
-    bad_date_list <- lapply(date_a_frame, function(i) {
-      setNames(original_dates, as.character(i))[i < dmin | i > dmax]
-    })
-  } else {
-    bad_date_list <- NULL
-  }
-  for (i in names(date_a_frame)) {
-    tmp <- date_a_frame[[i]]
-    date_a_frame[[i]][tmp < dmin | tmp > dmax] <- NA 
-  }
-  list(good_dates = date_a_frame, bad_dates = bad_date_list)
+constrain_dates <- function(new_dates, original_dates, dmin, dmax, baddies) {
+
+  # filter out the dates that are below the threshold
+  outsiders <- new_dates < dmin | new_dates > dmax
+  outsiders[is.na(outsiders)] <- FALSE
+
+  # record the bad dates in the environment
+  if (any(outsiders)) {
+    for (i in which(outsiders)) {
+      bad <- as.character(new_dates[i])
+      baddies[[bad]] <- c(baddies[[bad]], original_dates[i])
+    }
+  } 
+  # mark the bad dates as NA
+  new_dates[outsiders] <- as.Date(NA_character_)
+  
+  new_dates
+
 }
+
 
 
 #' Choose the first non-missing date from a data frame of dates
 #'
+#' @noRd
 #' @param date_a_frame a data frame where each column contains a different
 #'   parsing of the same date vector
 #' @keywords internal
-#' @noRd
-choose_first_good_date <- function(date_a_frame, original_dates) {
+choose_first_good_date <- function(date_a_frame) {
   n   <- nrow(date_a_frame)
+  date_a_frame <- as.matrix(date_a_frame)
   res <- rep(as.Date(NA), length = n)
   for (i in seq_len(n)) {
-    tmp <- date_a_frame[i, ]
-    res[i] <- tmp[!is.na(tmp)][1]
+    tmp    <- date_a_frame[i, , drop = TRUE]
+    res[i] <- as.Date(tmp[!is.na(tmp)][1])
   }
   res
 }
 
+
 #' Find the dates that lubridate couldn't
 #' 
+#' @noRd
 #' @param date_a_frame a data frame where each column contains a different
 #'   parsing of the same date vector
 #' @param original_dates the vector of original dates.
 #' @param mxl "modern excel" if TRUE, then it uses 1900 as the origin, otherwise
 #'   1904 is used as the origin.
+#' @param dmin the minimum dates
+#' @param dmax the maximum dates
+#' @param baddies an environment that will act as a list of bad dates. 
 #' @keywords internal
-#' @noRd
-rescue_lubridate_failures <- function(date_a_frame, original_dates, mxl = TRUE) {
-  nas     <- is.na(date_a_frame)
+rescue_lubridate_failures <- function(date_a_frame, original_dates, mxl = TRUE, dmin, dmax, baddies) {
+
   # Find places where all rows are missing
+  nas     <- is.na(date_a_frame)
   all_nas <- apply(nas, 1, all)
   numbers <- suppressWarnings(!is.na(o_num <- as.integer(original_dates)))
   go_tibo <- which(all_nas & !numbers)
   go_exel <- all_nas & numbers
-  # Use Thibaut's guesser instead
+
+  # Use Thibaut's guesser 
+  tmpbo   <- rep(as.Date(NA_character_), length(go_tibo))
   for (i in go_tibo) {
-    date_a_frame[i, 1] <- i_extract_date_string(original_dates[i])
+    tmpbo[go_tibo == i] <- i_extract_date_string(original_dates[i])
+    tmpbo <- constrain_dates(tmpbo, original_dates[go_tibo], dmin, dmax, baddies)
   }
+  date_a_frame[[1]][go_tibo] <- tmpbo
+
+  # Use the excel guesser
   if (sum(go_exel)) {
     origin <- if (mxl) as.Date("1900-01-01") else as.Date("1904-01-01")
-    date_a_frame[go_exel, 1] <- as.Date(o_num[go_exel], origin = origin)
+    tmpxl  <- as.Date(o_num[go_exel], origin = origin)
+    date_a_frame[[1]][go_exel] <- constrain_dates(tmpxl, original_dates[go_exel], dmin, dmax, baddies)
   }
+
   date_a_frame
 }

--- a/docs/CONDUCT.html
+++ b/docs/CONDUCT.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/LICENSE-text.html
+++ b/docs/LICENSE-text.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/articles/overview.html
+++ b/docs/articles/overview.html
@@ -82,7 +82,7 @@
     <div class="page-header toc-ignore">
       <h1>linelist: package overview</h1>
             
-            <h4 class="date">2019-05-14</h4>
+            <h4 class="date">2019-05-15</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/reconhub/linelist/blob/master/vignettes/overview.Rmd"><code>vignettes/overview.Rmd</code></a></small>
       <div class="hidden name"><code>overview.Rmd</code></div>

--- a/docs/articles/overview.html
+++ b/docs/articles/overview.html
@@ -30,7 +30,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 
@@ -82,7 +82,7 @@
     <div class="page-header toc-ignore">
       <h1>linelist: package overview</h1>
             
-            <h4 class="date">2019-05-03</h4>
+            <h4 class="date">2019-05-14</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/reconhub/linelist/blob/master/vignettes/overview.Rmd"><code>vignettes/overview.Rmd</code></a></small>
       <div class="hidden name"><code>overview.Rmd</code></div>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -167,47 +167,47 @@
 <a class="sourceLine" id="cb3-19" data-line-number="19"><span class="co">## show data</span></a>
 <a class="sourceLine" id="cb3-20" data-line-number="20">toy_data</a>
 <a class="sourceLine" id="cb3-21" data-line-number="21"><span class="co">#&gt;    Date.of.Onset. DisCharge..  SeX_. Épi.Case_définition</span></a>
-<a class="sourceLine" id="cb3-22" data-line-number="22"><span class="co">#&gt; 1      2018-01-09  19/01/2018   male          not a case</span></a>
-<a class="sourceLine" id="cb3-23" data-line-number="23"><span class="co">#&gt; 2      2018-01-05  15/01/2018   male           suspected</span></a>
-<a class="sourceLine" id="cb3-24" data-line-number="24"><span class="co">#&gt; 3      2018-01-02  12/01/2018 female          Not.a.Case</span></a>
-<a class="sourceLine" id="cb3-25" data-line-number="25"><span class="co">#&gt; 4      2018-01-07  17/01/2018 FEMALE           confirmed</span></a>
-<a class="sourceLine" id="cb3-26" data-line-number="26"><span class="co">#&gt; 5      2018-01-09  19/01/2018   Male            probable</span></a>
-<a class="sourceLine" id="cb3-27" data-line-number="27"><span class="co">#&gt; 6      2018-01-05  15/01/2018 female           Confirmed</span></a>
-<a class="sourceLine" id="cb3-28" data-line-number="28"><span class="co">#&gt; 7      2018-01-10  20/01/2018 female          not a case</span></a>
-<a class="sourceLine" id="cb3-29" data-line-number="29"><span class="co">#&gt; 8      2018-01-06  16/01/2018   MALE            probable</span></a>
-<a class="sourceLine" id="cb3-30" data-line-number="30"><span class="co">#&gt; 9      2018-01-08  18/01/2018 Female            probable</span></a>
-<a class="sourceLine" id="cb3-31" data-line-number="31"><span class="co">#&gt; 10     2018-01-08  18/01/2018   MALE           Confirmed</span></a>
-<a class="sourceLine" id="cb3-32" data-line-number="32"><span class="co">#&gt; 11     2018-01-10  20/01/2018   Male            PROBABLE</span></a>
-<a class="sourceLine" id="cb3-33" data-line-number="33"><span class="co">#&gt; 12     2018-01-11  21/01/2018 Female          Not.a.Case</span></a>
-<a class="sourceLine" id="cb3-34" data-line-number="34"><span class="co">#&gt; 13     2018-01-09  19/01/2018   MALE           Confirmed</span></a>
-<a class="sourceLine" id="cb3-35" data-line-number="35"><span class="co">#&gt; 14     2018-01-10  20/01/2018 Female            PROBABLE</span></a>
-<a class="sourceLine" id="cb3-36" data-line-number="36"><span class="co">#&gt; 15     2018-01-10  20/01/2018 female           Confirmed</span></a>
-<a class="sourceLine" id="cb3-37" data-line-number="37"><span class="co">#&gt; 16     2018-01-09  19/01/2018 Female            PROBABLE</span></a>
-<a class="sourceLine" id="cb3-38" data-line-number="38"><span class="co">#&gt; 17     2018-01-06  16/01/2018   male          not a case</span></a>
-<a class="sourceLine" id="cb3-39" data-line-number="39"><span class="co">#&gt; 18     2018-01-09  19/01/2018   MALE            probable</span></a>
-<a class="sourceLine" id="cb3-40" data-line-number="40"><span class="co">#&gt; 19     2018-01-11  21/01/2018   male           suspected</span></a>
-<a class="sourceLine" id="cb3-41" data-line-number="41"><span class="co">#&gt; 20     2018-01-06  16/01/2018   Male           suspected</span></a>
+<a class="sourceLine" id="cb3-22" data-line-number="22"><span class="co">#&gt; 1      2018-01-07  17/01/2018 female           suspected</span></a>
+<a class="sourceLine" id="cb3-23" data-line-number="23"><span class="co">#&gt; 2      2018-01-08  18/01/2018 FEMALE           Confirmed</span></a>
+<a class="sourceLine" id="cb3-24" data-line-number="24"><span class="co">#&gt; 3      2018-01-09  19/01/2018 Female          Not.a.Case</span></a>
+<a class="sourceLine" id="cb3-25" data-line-number="25"><span class="co">#&gt; 4      2018-01-07  17/01/2018   MALE            probable</span></a>
+<a class="sourceLine" id="cb3-26" data-line-number="26"><span class="co">#&gt; 5      2018-01-03  13/01/2018 female           confirmed</span></a>
+<a class="sourceLine" id="cb3-27" data-line-number="27"><span class="co">#&gt; 6      2018-01-11  21/01/2018 Female          not a case</span></a>
+<a class="sourceLine" id="cb3-28" data-line-number="28"><span class="co">#&gt; 7      2018-01-10  20/01/2018 FEMALE           confirmed</span></a>
+<a class="sourceLine" id="cb3-29" data-line-number="29"><span class="co">#&gt; 8      2018-01-11  21/01/2018   MALE            probable</span></a>
+<a class="sourceLine" id="cb3-30" data-line-number="30"><span class="co">#&gt; 9      2018-01-11  21/01/2018   MALE            probable</span></a>
+<a class="sourceLine" id="cb3-31" data-line-number="31"><span class="co">#&gt; 10     2018-01-11  21/01/2018   Male          Not.a.Case</span></a>
+<a class="sourceLine" id="cb3-32" data-line-number="32"><span class="co">#&gt; 11     2018-01-08  18/01/2018 female           Confirmed</span></a>
+<a class="sourceLine" id="cb3-33" data-line-number="33"><span class="co">#&gt; 12     2018-01-05  15/01/2018   MALE            PROBABLE</span></a>
+<a class="sourceLine" id="cb3-34" data-line-number="34"><span class="co">#&gt; 13     2018-01-05  15/01/2018   Male          Not.a.Case</span></a>
+<a class="sourceLine" id="cb3-35" data-line-number="35"><span class="co">#&gt; 14     2018-01-06  16/01/2018 FEMALE           Confirmed</span></a>
+<a class="sourceLine" id="cb3-36" data-line-number="36"><span class="co">#&gt; 15     2018-01-11  21/01/2018   Male          Not.a.Case</span></a>
+<a class="sourceLine" id="cb3-37" data-line-number="37"><span class="co">#&gt; 16     2018-01-07  17/01/2018   male            PROBABLE</span></a>
+<a class="sourceLine" id="cb3-38" data-line-number="38"><span class="co">#&gt; 17     2018-01-08  18/01/2018 FEMALE           suspected</span></a>
+<a class="sourceLine" id="cb3-39" data-line-number="39"><span class="co">#&gt; 18     2018-01-11  21/01/2018   male          Not.a.Case</span></a>
+<a class="sourceLine" id="cb3-40" data-line-number="40"><span class="co">#&gt; 19     2018-01-04  14/01/2018 Female          not a case</span></a>
+<a class="sourceLine" id="cb3-41" data-line-number="41"><span class="co">#&gt; 20     2018-01-05  15/01/2018   Male            probable</span></a>
 <a class="sourceLine" id="cb3-42" data-line-number="42"><span class="co">#&gt;           messy.dates</span></a>
-<a class="sourceLine" id="cb3-43" data-line-number="43"><span class="co">#&gt; 1                male</span></a>
-<a class="sourceLine" id="cb3-44" data-line-number="44"><span class="co">#&gt; 2          01-12-2001</span></a>
-<a class="sourceLine" id="cb3-45" data-line-number="45"><span class="co">#&gt; 3              female</span></a>
-<a class="sourceLine" id="cb3-46" data-line-number="46"><span class="co">#&gt; 4          01-12-2001</span></a>
-<a class="sourceLine" id="cb3-47" data-line-number="47"><span class="co">#&gt; 5          2018_10_17</span></a>
+<a class="sourceLine" id="cb3-43" data-line-number="43"><span class="co">#&gt; 1          2018_10_17</span></a>
+<a class="sourceLine" id="cb3-44" data-line-number="44"><span class="co">#&gt; 2              female</span></a>
+<a class="sourceLine" id="cb3-45" data-line-number="45"><span class="co">#&gt; 3          01-12-2001</span></a>
+<a class="sourceLine" id="cb3-46" data-line-number="46"><span class="co">#&gt; 4          2018-10-18</span></a>
+<a class="sourceLine" id="cb3-47" data-line-number="47"><span class="co">#&gt; 5                male</span></a>
 <a class="sourceLine" id="cb3-48" data-line-number="48"><span class="co">#&gt; 6     // 24//12//1989</span></a>
-<a class="sourceLine" id="cb3-49" data-line-number="49"><span class="co">#&gt; 7              female</span></a>
-<a class="sourceLine" id="cb3-50" data-line-number="50"><span class="co">#&gt; 8          2018-10-18</span></a>
+<a class="sourceLine" id="cb3-49" data-line-number="49"><span class="co">#&gt; 7  that's 24/12/1989!</span></a>
+<a class="sourceLine" id="cb3-50" data-line-number="50"><span class="co">#&gt; 8  that's 24/12/1989!</span></a>
 <a class="sourceLine" id="cb3-51" data-line-number="51"><span class="co">#&gt; 9          2018_10_17</span></a>
-<a class="sourceLine" id="cb3-52" data-line-number="52"><span class="co">#&gt; 10         2018-10-18</span></a>
-<a class="sourceLine" id="cb3-53" data-line-number="53"><span class="co">#&gt; 11         2018_10_17</span></a>
-<a class="sourceLine" id="cb3-54" data-line-number="54"><span class="co">#&gt; 12    // 24//12//1989</span></a>
-<a class="sourceLine" id="cb3-55" data-line-number="55"><span class="co">#&gt; 13               male</span></a>
-<a class="sourceLine" id="cb3-56" data-line-number="56"><span class="co">#&gt; 14 that's 24/12/1989!</span></a>
-<a class="sourceLine" id="cb3-57" data-line-number="57"><span class="co">#&gt; 15         2018 10 19</span></a>
-<a class="sourceLine" id="cb3-58" data-line-number="58"><span class="co">#&gt; 16         2018 10 19</span></a>
-<a class="sourceLine" id="cb3-59" data-line-number="59"><span class="co">#&gt; 17             female</span></a>
+<a class="sourceLine" id="cb3-52" data-line-number="52"><span class="co">#&gt; 10         2018 10 19</span></a>
+<a class="sourceLine" id="cb3-53" data-line-number="53"><span class="co">#&gt; 11               &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb3-54" data-line-number="54"><span class="co">#&gt; 12         01-12-2001</span></a>
+<a class="sourceLine" id="cb3-55" data-line-number="55"><span class="co">#&gt; 13         01-12-2001</span></a>
+<a class="sourceLine" id="cb3-56" data-line-number="56"><span class="co">#&gt; 14               &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb3-57" data-line-number="57"><span class="co">#&gt; 15         2018_10_17</span></a>
+<a class="sourceLine" id="cb3-58" data-line-number="58"><span class="co">#&gt; 16               &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb3-59" data-line-number="59"><span class="co">#&gt; 17         2018_10_17</span></a>
 <a class="sourceLine" id="cb3-60" data-line-number="60"><span class="co">#&gt; 18               &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb3-61" data-line-number="61"><span class="co">#&gt; 19         2018_10_17</span></a>
-<a class="sourceLine" id="cb3-62" data-line-number="62"><span class="co">#&gt; 20    // 24//12//1989</span></a></code></pre></div>
+<a class="sourceLine" id="cb3-61" data-line-number="61"><span class="co">#&gt; 19    // 24//12//1989</span></a>
+<a class="sourceLine" id="cb3-62" data-line-number="62"><span class="co">#&gt; 20               &lt;NA&gt;</span></a></code></pre></div>
 <p>We start by cleaning these data:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1"><span class="co">## load library</span></a>
 <a class="sourceLine" id="cb4-2" data-line-number="2"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(linelist)</a>
@@ -216,26 +216,26 @@
 <a class="sourceLine" id="cb4-5" data-line-number="5">x &lt;-<span class="st"> </span><span class="kw"><a href="reference/clean_data.html">clean_data</a></span>(toy_data)</a>
 <a class="sourceLine" id="cb4-6" data-line-number="6">x</a>
 <a class="sourceLine" id="cb4-7" data-line-number="7"><span class="co">#&gt;    date_of_onset  discharge    sex epi_case_definition messy_dates</span></a>
-<a class="sourceLine" id="cb4-8" data-line-number="8"><span class="co">#&gt; 1     2018-01-09 2018-01-19   male          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-9" data-line-number="9"><span class="co">#&gt; 2     2018-01-05 2018-01-15   male           suspected  2001-12-01</span></a>
-<a class="sourceLine" id="cb4-10" data-line-number="10"><span class="co">#&gt; 3     2018-01-02 2018-01-12 female          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-11" data-line-number="11"><span class="co">#&gt; 4     2018-01-07 2018-01-17 female           confirmed  2001-12-01</span></a>
-<a class="sourceLine" id="cb4-12" data-line-number="12"><span class="co">#&gt; 5     2018-01-09 2018-01-19   male            probable  2018-10-17</span></a>
-<a class="sourceLine" id="cb4-13" data-line-number="13"><span class="co">#&gt; 6     2018-01-05 2018-01-15 female           confirmed  1989-12-24</span></a>
-<a class="sourceLine" id="cb4-14" data-line-number="14"><span class="co">#&gt; 7     2018-01-10 2018-01-20 female          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-15" data-line-number="15"><span class="co">#&gt; 8     2018-01-06 2018-01-16   male            probable  2018-10-18</span></a>
-<a class="sourceLine" id="cb4-16" data-line-number="16"><span class="co">#&gt; 9     2018-01-08 2018-01-18 female            probable  2018-10-17</span></a>
-<a class="sourceLine" id="cb4-17" data-line-number="17"><span class="co">#&gt; 10    2018-01-08 2018-01-18   male           confirmed  2018-10-18</span></a>
-<a class="sourceLine" id="cb4-18" data-line-number="18"><span class="co">#&gt; 11    2018-01-10 2018-01-20   male            probable  2018-10-17</span></a>
-<a class="sourceLine" id="cb4-19" data-line-number="19"><span class="co">#&gt; 12    2018-01-11 2018-01-21 female          not_a_case  1989-12-24</span></a>
-<a class="sourceLine" id="cb4-20" data-line-number="20"><span class="co">#&gt; 13    2018-01-09 2018-01-19   male           confirmed        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-21" data-line-number="21"><span class="co">#&gt; 14    2018-01-10 2018-01-20 female            probable  1989-12-24</span></a>
-<a class="sourceLine" id="cb4-22" data-line-number="22"><span class="co">#&gt; 15    2018-01-10 2018-01-20 female           confirmed  2018-10-19</span></a>
-<a class="sourceLine" id="cb4-23" data-line-number="23"><span class="co">#&gt; 16    2018-01-09 2018-01-19 female            probable  2018-10-19</span></a>
-<a class="sourceLine" id="cb4-24" data-line-number="24"><span class="co">#&gt; 17    2018-01-06 2018-01-16   male          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-25" data-line-number="25"><span class="co">#&gt; 18    2018-01-09 2018-01-19   male            probable        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-26" data-line-number="26"><span class="co">#&gt; 19    2018-01-11 2018-01-21   male           suspected  2018-10-17</span></a>
-<a class="sourceLine" id="cb4-27" data-line-number="27"><span class="co">#&gt; 20    2018-01-06 2018-01-16   male           suspected  1989-12-24</span></a></code></pre></div>
+<a class="sourceLine" id="cb4-8" data-line-number="8"><span class="co">#&gt; 1     2018-01-07 2018-01-17 female           suspected  2018-10-17</span></a>
+<a class="sourceLine" id="cb4-9" data-line-number="9"><span class="co">#&gt; 2     2018-01-08 2018-01-18 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-10" data-line-number="10"><span class="co">#&gt; 3     2018-01-09 2018-01-19 female          not_a_case  2001-12-01</span></a>
+<a class="sourceLine" id="cb4-11" data-line-number="11"><span class="co">#&gt; 4     2018-01-07 2018-01-17   male            probable  2018-10-18</span></a>
+<a class="sourceLine" id="cb4-12" data-line-number="12"><span class="co">#&gt; 5     2018-01-03 2018-01-13 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-13" data-line-number="13"><span class="co">#&gt; 6     2018-01-11 2018-01-21 female          not_a_case  1989-12-24</span></a>
+<a class="sourceLine" id="cb4-14" data-line-number="14"><span class="co">#&gt; 7     2018-01-10 2018-01-20 female           confirmed  1989-12-24</span></a>
+<a class="sourceLine" id="cb4-15" data-line-number="15"><span class="co">#&gt; 8     2018-01-11 2018-01-21   male            probable  1989-12-24</span></a>
+<a class="sourceLine" id="cb4-16" data-line-number="16"><span class="co">#&gt; 9     2018-01-11 2018-01-21   male            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb4-17" data-line-number="17"><span class="co">#&gt; 10    2018-01-11 2018-01-21   male          not_a_case  2018-10-19</span></a>
+<a class="sourceLine" id="cb4-18" data-line-number="18"><span class="co">#&gt; 11    2018-01-08 2018-01-18 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-19" data-line-number="19"><span class="co">#&gt; 12    2018-01-05 2018-01-15   male            probable  2001-12-01</span></a>
+<a class="sourceLine" id="cb4-20" data-line-number="20"><span class="co">#&gt; 13    2018-01-05 2018-01-15   male          not_a_case  2001-12-01</span></a>
+<a class="sourceLine" id="cb4-21" data-line-number="21"><span class="co">#&gt; 14    2018-01-06 2018-01-16 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-22" data-line-number="22"><span class="co">#&gt; 15    2018-01-11 2018-01-21   male          not_a_case  2018-10-17</span></a>
+<a class="sourceLine" id="cb4-23" data-line-number="23"><span class="co">#&gt; 16    2018-01-07 2018-01-17   male            probable        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-24" data-line-number="24"><span class="co">#&gt; 17    2018-01-08 2018-01-18 female           suspected  2018-10-17</span></a>
+<a class="sourceLine" id="cb4-25" data-line-number="25"><span class="co">#&gt; 18    2018-01-11 2018-01-21   male          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-26" data-line-number="26"><span class="co">#&gt; 19    2018-01-04 2018-01-14 female          not_a_case  1989-12-24</span></a>
+<a class="sourceLine" id="cb4-27" data-line-number="27"><span class="co">#&gt; 20    2018-01-05 2018-01-15   male            probable        &lt;NA&gt;</span></a></code></pre></div>
 <p>We can now define some <code>epivars</code> for <code>x</code>, i.e. identify which columns correspond to typical epidemiological variables:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1"><span class="co">## see what the dictionary is</span></a>
 <a class="sourceLine" id="cb5-2" data-line-number="2"><span class="kw"><a href="reference/dictionary.html">get_dictionary</a></span>()</a>
@@ -276,26 +276,26 @@
 <a class="sourceLine" id="cb5-37" data-line-number="37"><span class="co">#&gt; &lt;linelist object&gt;</span></a>
 <a class="sourceLine" id="cb5-38" data-line-number="38"><span class="co">#&gt; </span></a>
 <a class="sourceLine" id="cb5-39" data-line-number="39"><span class="co">#&gt;    date_of_onset  discharge    sex epi_case_definition messy_dates</span></a>
-<a class="sourceLine" id="cb5-40" data-line-number="40"><span class="co">#&gt; 1     2018-01-09 2018-01-19   male          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-41" data-line-number="41"><span class="co">#&gt; 2     2018-01-05 2018-01-15   male           suspected  2001-12-01</span></a>
-<a class="sourceLine" id="cb5-42" data-line-number="42"><span class="co">#&gt; 3     2018-01-02 2018-01-12 female          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-43" data-line-number="43"><span class="co">#&gt; 4     2018-01-07 2018-01-17 female           confirmed  2001-12-01</span></a>
-<a class="sourceLine" id="cb5-44" data-line-number="44"><span class="co">#&gt; 5     2018-01-09 2018-01-19   male            probable  2018-10-17</span></a>
-<a class="sourceLine" id="cb5-45" data-line-number="45"><span class="co">#&gt; 6     2018-01-05 2018-01-15 female           confirmed  1989-12-24</span></a>
-<a class="sourceLine" id="cb5-46" data-line-number="46"><span class="co">#&gt; 7     2018-01-10 2018-01-20 female          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-47" data-line-number="47"><span class="co">#&gt; 8     2018-01-06 2018-01-16   male            probable  2018-10-18</span></a>
-<a class="sourceLine" id="cb5-48" data-line-number="48"><span class="co">#&gt; 9     2018-01-08 2018-01-18 female            probable  2018-10-17</span></a>
-<a class="sourceLine" id="cb5-49" data-line-number="49"><span class="co">#&gt; 10    2018-01-08 2018-01-18   male           confirmed  2018-10-18</span></a>
-<a class="sourceLine" id="cb5-50" data-line-number="50"><span class="co">#&gt; 11    2018-01-10 2018-01-20   male            probable  2018-10-17</span></a>
-<a class="sourceLine" id="cb5-51" data-line-number="51"><span class="co">#&gt; 12    2018-01-11 2018-01-21 female          not_a_case  1989-12-24</span></a>
-<a class="sourceLine" id="cb5-52" data-line-number="52"><span class="co">#&gt; 13    2018-01-09 2018-01-19   male           confirmed        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-53" data-line-number="53"><span class="co">#&gt; 14    2018-01-10 2018-01-20 female            probable  1989-12-24</span></a>
-<a class="sourceLine" id="cb5-54" data-line-number="54"><span class="co">#&gt; 15    2018-01-10 2018-01-20 female           confirmed  2018-10-19</span></a>
-<a class="sourceLine" id="cb5-55" data-line-number="55"><span class="co">#&gt; 16    2018-01-09 2018-01-19 female            probable  2018-10-19</span></a>
-<a class="sourceLine" id="cb5-56" data-line-number="56"><span class="co">#&gt; 17    2018-01-06 2018-01-16   male          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-57" data-line-number="57"><span class="co">#&gt; 18    2018-01-09 2018-01-19   male            probable        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-58" data-line-number="58"><span class="co">#&gt; 19    2018-01-11 2018-01-21   male           suspected  2018-10-17</span></a>
-<a class="sourceLine" id="cb5-59" data-line-number="59"><span class="co">#&gt; 20    2018-01-06 2018-01-16   male           suspected  1989-12-24</span></a></code></pre></div>
+<a class="sourceLine" id="cb5-40" data-line-number="40"><span class="co">#&gt; 1     2018-01-07 2018-01-17 female           suspected  2018-10-17</span></a>
+<a class="sourceLine" id="cb5-41" data-line-number="41"><span class="co">#&gt; 2     2018-01-08 2018-01-18 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-42" data-line-number="42"><span class="co">#&gt; 3     2018-01-09 2018-01-19 female          not_a_case  2001-12-01</span></a>
+<a class="sourceLine" id="cb5-43" data-line-number="43"><span class="co">#&gt; 4     2018-01-07 2018-01-17   male            probable  2018-10-18</span></a>
+<a class="sourceLine" id="cb5-44" data-line-number="44"><span class="co">#&gt; 5     2018-01-03 2018-01-13 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-45" data-line-number="45"><span class="co">#&gt; 6     2018-01-11 2018-01-21 female          not_a_case  1989-12-24</span></a>
+<a class="sourceLine" id="cb5-46" data-line-number="46"><span class="co">#&gt; 7     2018-01-10 2018-01-20 female           confirmed  1989-12-24</span></a>
+<a class="sourceLine" id="cb5-47" data-line-number="47"><span class="co">#&gt; 8     2018-01-11 2018-01-21   male            probable  1989-12-24</span></a>
+<a class="sourceLine" id="cb5-48" data-line-number="48"><span class="co">#&gt; 9     2018-01-11 2018-01-21   male            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb5-49" data-line-number="49"><span class="co">#&gt; 10    2018-01-11 2018-01-21   male          not_a_case  2018-10-19</span></a>
+<a class="sourceLine" id="cb5-50" data-line-number="50"><span class="co">#&gt; 11    2018-01-08 2018-01-18 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-51" data-line-number="51"><span class="co">#&gt; 12    2018-01-05 2018-01-15   male            probable  2001-12-01</span></a>
+<a class="sourceLine" id="cb5-52" data-line-number="52"><span class="co">#&gt; 13    2018-01-05 2018-01-15   male          not_a_case  2001-12-01</span></a>
+<a class="sourceLine" id="cb5-53" data-line-number="53"><span class="co">#&gt; 14    2018-01-06 2018-01-16 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-54" data-line-number="54"><span class="co">#&gt; 15    2018-01-11 2018-01-21   male          not_a_case  2018-10-17</span></a>
+<a class="sourceLine" id="cb5-55" data-line-number="55"><span class="co">#&gt; 16    2018-01-07 2018-01-17   male            probable        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-56" data-line-number="56"><span class="co">#&gt; 17    2018-01-08 2018-01-18 female           suspected  2018-10-17</span></a>
+<a class="sourceLine" id="cb5-57" data-line-number="57"><span class="co">#&gt; 18    2018-01-11 2018-01-21   male          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-58" data-line-number="58"><span class="co">#&gt; 19    2018-01-04 2018-01-14 female          not_a_case  1989-12-24</span></a>
+<a class="sourceLine" id="cb5-59" data-line-number="59"><span class="co">#&gt; 20    2018-01-05 2018-01-15   male            probable        &lt;NA&gt;</span></a></code></pre></div>
 <p>Note that the equivalent can be done using piping:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(magrittr)</a>
 <a class="sourceLine" id="cb6-2" data-line-number="2">x &lt;-<span class="st"> </span>toy_data <span class="op">%&gt;%</span></a>
@@ -305,26 +305,26 @@
 <a class="sourceLine" id="cb6-6" data-line-number="6"><span class="co">#&gt; &lt;linelist object&gt;</span></a>
 <a class="sourceLine" id="cb6-7" data-line-number="7"><span class="co">#&gt; </span></a>
 <a class="sourceLine" id="cb6-8" data-line-number="8"><span class="co">#&gt;    date_of_onset  discharge    sex epi_case_definition messy_dates</span></a>
-<a class="sourceLine" id="cb6-9" data-line-number="9"><span class="co">#&gt; 1     2018-01-09 2018-01-19   male          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-10" data-line-number="10"><span class="co">#&gt; 2     2018-01-05 2018-01-15   male           suspected  2001-12-01</span></a>
-<a class="sourceLine" id="cb6-11" data-line-number="11"><span class="co">#&gt; 3     2018-01-02 2018-01-12 female          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-12" data-line-number="12"><span class="co">#&gt; 4     2018-01-07 2018-01-17 female           confirmed  2001-12-01</span></a>
-<a class="sourceLine" id="cb6-13" data-line-number="13"><span class="co">#&gt; 5     2018-01-09 2018-01-19   male            probable  2018-10-17</span></a>
-<a class="sourceLine" id="cb6-14" data-line-number="14"><span class="co">#&gt; 6     2018-01-05 2018-01-15 female           confirmed  1989-12-24</span></a>
-<a class="sourceLine" id="cb6-15" data-line-number="15"><span class="co">#&gt; 7     2018-01-10 2018-01-20 female          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-16" data-line-number="16"><span class="co">#&gt; 8     2018-01-06 2018-01-16   male            probable  2018-10-18</span></a>
-<a class="sourceLine" id="cb6-17" data-line-number="17"><span class="co">#&gt; 9     2018-01-08 2018-01-18 female            probable  2018-10-17</span></a>
-<a class="sourceLine" id="cb6-18" data-line-number="18"><span class="co">#&gt; 10    2018-01-08 2018-01-18   male           confirmed  2018-10-18</span></a>
-<a class="sourceLine" id="cb6-19" data-line-number="19"><span class="co">#&gt; 11    2018-01-10 2018-01-20   male            probable  2018-10-17</span></a>
-<a class="sourceLine" id="cb6-20" data-line-number="20"><span class="co">#&gt; 12    2018-01-11 2018-01-21 female          not_a_case  1989-12-24</span></a>
-<a class="sourceLine" id="cb6-21" data-line-number="21"><span class="co">#&gt; 13    2018-01-09 2018-01-19   male           confirmed        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-22" data-line-number="22"><span class="co">#&gt; 14    2018-01-10 2018-01-20 female            probable  1989-12-24</span></a>
-<a class="sourceLine" id="cb6-23" data-line-number="23"><span class="co">#&gt; 15    2018-01-10 2018-01-20 female           confirmed  2018-10-19</span></a>
-<a class="sourceLine" id="cb6-24" data-line-number="24"><span class="co">#&gt; 16    2018-01-09 2018-01-19 female            probable  2018-10-19</span></a>
-<a class="sourceLine" id="cb6-25" data-line-number="25"><span class="co">#&gt; 17    2018-01-06 2018-01-16   male          not_a_case        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-26" data-line-number="26"><span class="co">#&gt; 18    2018-01-09 2018-01-19   male            probable        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-27" data-line-number="27"><span class="co">#&gt; 19    2018-01-11 2018-01-21   male           suspected  2018-10-17</span></a>
-<a class="sourceLine" id="cb6-28" data-line-number="28"><span class="co">#&gt; 20    2018-01-06 2018-01-16   male           suspected  1989-12-24</span></a></code></pre></div>
+<a class="sourceLine" id="cb6-9" data-line-number="9"><span class="co">#&gt; 1     2018-01-07 2018-01-17 female           suspected  2018-10-17</span></a>
+<a class="sourceLine" id="cb6-10" data-line-number="10"><span class="co">#&gt; 2     2018-01-08 2018-01-18 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-11" data-line-number="11"><span class="co">#&gt; 3     2018-01-09 2018-01-19 female          not_a_case  2001-12-01</span></a>
+<a class="sourceLine" id="cb6-12" data-line-number="12"><span class="co">#&gt; 4     2018-01-07 2018-01-17   male            probable  2018-10-18</span></a>
+<a class="sourceLine" id="cb6-13" data-line-number="13"><span class="co">#&gt; 5     2018-01-03 2018-01-13 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-14" data-line-number="14"><span class="co">#&gt; 6     2018-01-11 2018-01-21 female          not_a_case  1989-12-24</span></a>
+<a class="sourceLine" id="cb6-15" data-line-number="15"><span class="co">#&gt; 7     2018-01-10 2018-01-20 female           confirmed  1989-12-24</span></a>
+<a class="sourceLine" id="cb6-16" data-line-number="16"><span class="co">#&gt; 8     2018-01-11 2018-01-21   male            probable  1989-12-24</span></a>
+<a class="sourceLine" id="cb6-17" data-line-number="17"><span class="co">#&gt; 9     2018-01-11 2018-01-21   male            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb6-18" data-line-number="18"><span class="co">#&gt; 10    2018-01-11 2018-01-21   male          not_a_case  2018-10-19</span></a>
+<a class="sourceLine" id="cb6-19" data-line-number="19"><span class="co">#&gt; 11    2018-01-08 2018-01-18 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-20" data-line-number="20"><span class="co">#&gt; 12    2018-01-05 2018-01-15   male            probable  2001-12-01</span></a>
+<a class="sourceLine" id="cb6-21" data-line-number="21"><span class="co">#&gt; 13    2018-01-05 2018-01-15   male          not_a_case  2001-12-01</span></a>
+<a class="sourceLine" id="cb6-22" data-line-number="22"><span class="co">#&gt; 14    2018-01-06 2018-01-16 female           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-23" data-line-number="23"><span class="co">#&gt; 15    2018-01-11 2018-01-21   male          not_a_case  2018-10-17</span></a>
+<a class="sourceLine" id="cb6-24" data-line-number="24"><span class="co">#&gt; 16    2018-01-07 2018-01-17   male            probable        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-25" data-line-number="25"><span class="co">#&gt; 17    2018-01-08 2018-01-18 female           suspected  2018-10-17</span></a>
+<a class="sourceLine" id="cb6-26" data-line-number="26"><span class="co">#&gt; 18    2018-01-11 2018-01-21   male          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-27" data-line-number="27"><span class="co">#&gt; 19    2018-01-04 2018-01-14 female          not_a_case  1989-12-24</span></a>
+<a class="sourceLine" id="cb6-28" data-line-number="28"><span class="co">#&gt; 20    2018-01-05 2018-01-15   male            probable        &lt;NA&gt;</span></a></code></pre></div>
 <p>We now handle a clean dataset, with standardised labels and variable names, and dates of onset and gender are now formally identifier:</p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1"><span class="co">## check available epivars</span></a>
 <a class="sourceLine" id="cb7-2" data-line-number="2"><span class="kw"><a href="reference/list_epivars.html">list_epivars</a></span>(x, <span class="dt">simple =</span> <span class="ot">TRUE</span>) <span class="co"># simple</span></a>
@@ -337,26 +337,26 @@
 <a class="sourceLine" id="cb7-9" data-line-number="9"></a>
 <a class="sourceLine" id="cb7-10" data-line-number="10"><span class="kw"><a href="reference/accessors.html">get_epivars</a></span>(x, <span class="st">"gender"</span>, <span class="st">"date_onset"</span>)</a>
 <a class="sourceLine" id="cb7-11" data-line-number="11"><span class="co">#&gt;       sex date_of_onset</span></a>
-<a class="sourceLine" id="cb7-12" data-line-number="12"><span class="co">#&gt; 1    male    2018-01-09</span></a>
-<a class="sourceLine" id="cb7-13" data-line-number="13"><span class="co">#&gt; 2    male    2018-01-05</span></a>
-<a class="sourceLine" id="cb7-14" data-line-number="14"><span class="co">#&gt; 3  female    2018-01-02</span></a>
-<a class="sourceLine" id="cb7-15" data-line-number="15"><span class="co">#&gt; 4  female    2018-01-07</span></a>
-<a class="sourceLine" id="cb7-16" data-line-number="16"><span class="co">#&gt; 5    male    2018-01-09</span></a>
-<a class="sourceLine" id="cb7-17" data-line-number="17"><span class="co">#&gt; 6  female    2018-01-05</span></a>
+<a class="sourceLine" id="cb7-12" data-line-number="12"><span class="co">#&gt; 1  female    2018-01-07</span></a>
+<a class="sourceLine" id="cb7-13" data-line-number="13"><span class="co">#&gt; 2  female    2018-01-08</span></a>
+<a class="sourceLine" id="cb7-14" data-line-number="14"><span class="co">#&gt; 3  female    2018-01-09</span></a>
+<a class="sourceLine" id="cb7-15" data-line-number="15"><span class="co">#&gt; 4    male    2018-01-07</span></a>
+<a class="sourceLine" id="cb7-16" data-line-number="16"><span class="co">#&gt; 5  female    2018-01-03</span></a>
+<a class="sourceLine" id="cb7-17" data-line-number="17"><span class="co">#&gt; 6  female    2018-01-11</span></a>
 <a class="sourceLine" id="cb7-18" data-line-number="18"><span class="co">#&gt; 7  female    2018-01-10</span></a>
-<a class="sourceLine" id="cb7-19" data-line-number="19"><span class="co">#&gt; 8    male    2018-01-06</span></a>
-<a class="sourceLine" id="cb7-20" data-line-number="20"><span class="co">#&gt; 9  female    2018-01-08</span></a>
-<a class="sourceLine" id="cb7-21" data-line-number="21"><span class="co">#&gt; 10   male    2018-01-08</span></a>
-<a class="sourceLine" id="cb7-22" data-line-number="22"><span class="co">#&gt; 11   male    2018-01-10</span></a>
-<a class="sourceLine" id="cb7-23" data-line-number="23"><span class="co">#&gt; 12 female    2018-01-11</span></a>
-<a class="sourceLine" id="cb7-24" data-line-number="24"><span class="co">#&gt; 13   male    2018-01-09</span></a>
-<a class="sourceLine" id="cb7-25" data-line-number="25"><span class="co">#&gt; 14 female    2018-01-10</span></a>
-<a class="sourceLine" id="cb7-26" data-line-number="26"><span class="co">#&gt; 15 female    2018-01-10</span></a>
-<a class="sourceLine" id="cb7-27" data-line-number="27"><span class="co">#&gt; 16 female    2018-01-09</span></a>
-<a class="sourceLine" id="cb7-28" data-line-number="28"><span class="co">#&gt; 17   male    2018-01-06</span></a>
-<a class="sourceLine" id="cb7-29" data-line-number="29"><span class="co">#&gt; 18   male    2018-01-09</span></a>
-<a class="sourceLine" id="cb7-30" data-line-number="30"><span class="co">#&gt; 19   male    2018-01-11</span></a>
-<a class="sourceLine" id="cb7-31" data-line-number="31"><span class="co">#&gt; 20   male    2018-01-06</span></a></code></pre></div>
+<a class="sourceLine" id="cb7-19" data-line-number="19"><span class="co">#&gt; 8    male    2018-01-11</span></a>
+<a class="sourceLine" id="cb7-20" data-line-number="20"><span class="co">#&gt; 9    male    2018-01-11</span></a>
+<a class="sourceLine" id="cb7-21" data-line-number="21"><span class="co">#&gt; 10   male    2018-01-11</span></a>
+<a class="sourceLine" id="cb7-22" data-line-number="22"><span class="co">#&gt; 11 female    2018-01-08</span></a>
+<a class="sourceLine" id="cb7-23" data-line-number="23"><span class="co">#&gt; 12   male    2018-01-05</span></a>
+<a class="sourceLine" id="cb7-24" data-line-number="24"><span class="co">#&gt; 13   male    2018-01-05</span></a>
+<a class="sourceLine" id="cb7-25" data-line-number="25"><span class="co">#&gt; 14 female    2018-01-06</span></a>
+<a class="sourceLine" id="cb7-26" data-line-number="26"><span class="co">#&gt; 15   male    2018-01-11</span></a>
+<a class="sourceLine" id="cb7-27" data-line-number="27"><span class="co">#&gt; 16   male    2018-01-07</span></a>
+<a class="sourceLine" id="cb7-28" data-line-number="28"><span class="co">#&gt; 17 female    2018-01-08</span></a>
+<a class="sourceLine" id="cb7-29" data-line-number="29"><span class="co">#&gt; 18   male    2018-01-11</span></a>
+<a class="sourceLine" id="cb7-30" data-line-number="30"><span class="co">#&gt; 19 female    2018-01-04</span></a>
+<a class="sourceLine" id="cb7-31" data-line-number="31"><span class="co">#&gt; 20   male    2018-01-05</span></a></code></pre></div>
 <div id="getting-help-online" class="section level2">
 <h2 class="hasAnchor">
 <a href="#getting-help-online" class="anchor"></a>Getting help online</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 
@@ -167,47 +167,47 @@
 <a class="sourceLine" id="cb3-19" data-line-number="19"><span class="co">## show data</span></a>
 <a class="sourceLine" id="cb3-20" data-line-number="20">toy_data</a>
 <a class="sourceLine" id="cb3-21" data-line-number="21"><span class="co">#&gt;    Date.of.Onset. DisCharge..  SeX_. Épi.Case_définition</span></a>
-<a class="sourceLine" id="cb3-22" data-line-number="22"><span class="co">#&gt; 1      2018-01-11  21/01/2018 female         suspected  </span></a>
-<a class="sourceLine" id="cb3-23" data-line-number="23"><span class="co">#&gt; 2      2018-01-11  21/01/2018 FEMALE            PROBABLE</span></a>
-<a class="sourceLine" id="cb3-24" data-line-number="24"><span class="co">#&gt; 3      2018-01-03  13/01/2018 female            PROBABLE</span></a>
-<a class="sourceLine" id="cb3-25" data-line-number="25"><span class="co">#&gt; 4      2018-01-02  12/01/2018   Male           suspected</span></a>
-<a class="sourceLine" id="cb3-26" data-line-number="26"><span class="co">#&gt; 5      2018-01-04  14/01/2018 FEMALE         suspected  </span></a>
-<a class="sourceLine" id="cb3-27" data-line-number="27"><span class="co">#&gt; 6      2018-01-06  16/01/2018 female         suspected  </span></a>
-<a class="sourceLine" id="cb3-28" data-line-number="28"><span class="co">#&gt; 7      2018-01-07  17/01/2018   Male         suspected  </span></a>
-<a class="sourceLine" id="cb3-29" data-line-number="29"><span class="co">#&gt; 8      2018-01-02  12/01/2018   Male          Not.a.Case</span></a>
-<a class="sourceLine" id="cb3-30" data-line-number="30"><span class="co">#&gt; 9      2018-01-04  14/01/2018 FEMALE           suspected</span></a>
-<a class="sourceLine" id="cb3-31" data-line-number="31"><span class="co">#&gt; 10     2018-01-07  17/01/2018   MALE           Confirmed</span></a>
-<a class="sourceLine" id="cb3-32" data-line-number="32"><span class="co">#&gt; 11     2018-01-10  20/01/2018 Female          not a case</span></a>
-<a class="sourceLine" id="cb3-33" data-line-number="33"><span class="co">#&gt; 12     2018-01-08  18/01/2018   MALE           confirmed</span></a>
-<a class="sourceLine" id="cb3-34" data-line-number="34"><span class="co">#&gt; 13     2018-01-03  13/01/2018 female          Not.a.Case</span></a>
-<a class="sourceLine" id="cb3-35" data-line-number="35"><span class="co">#&gt; 14     2018-01-10  20/01/2018 FEMALE           Confirmed</span></a>
-<a class="sourceLine" id="cb3-36" data-line-number="36"><span class="co">#&gt; 15     2018-01-11  21/01/2018 female          Not.a.Case</span></a>
-<a class="sourceLine" id="cb3-37" data-line-number="37"><span class="co">#&gt; 16     2018-01-05  15/01/2018   male          not a case</span></a>
-<a class="sourceLine" id="cb3-38" data-line-number="38"><span class="co">#&gt; 17     2018-01-08  18/01/2018 female           confirmed</span></a>
-<a class="sourceLine" id="cb3-39" data-line-number="39"><span class="co">#&gt; 18     2018-01-04  14/01/2018 Female            probable</span></a>
-<a class="sourceLine" id="cb3-40" data-line-number="40"><span class="co">#&gt; 19     2018-01-09  19/01/2018   MALE         suspected  </span></a>
-<a class="sourceLine" id="cb3-41" data-line-number="41"><span class="co">#&gt; 20     2018-01-11  21/01/2018   Male           Confirmed</span></a>
+<a class="sourceLine" id="cb3-22" data-line-number="22"><span class="co">#&gt; 1      2018-01-09  19/01/2018   male          not a case</span></a>
+<a class="sourceLine" id="cb3-23" data-line-number="23"><span class="co">#&gt; 2      2018-01-05  15/01/2018   male           suspected</span></a>
+<a class="sourceLine" id="cb3-24" data-line-number="24"><span class="co">#&gt; 3      2018-01-02  12/01/2018 female          Not.a.Case</span></a>
+<a class="sourceLine" id="cb3-25" data-line-number="25"><span class="co">#&gt; 4      2018-01-07  17/01/2018 FEMALE           confirmed</span></a>
+<a class="sourceLine" id="cb3-26" data-line-number="26"><span class="co">#&gt; 5      2018-01-09  19/01/2018   Male            probable</span></a>
+<a class="sourceLine" id="cb3-27" data-line-number="27"><span class="co">#&gt; 6      2018-01-05  15/01/2018 female           Confirmed</span></a>
+<a class="sourceLine" id="cb3-28" data-line-number="28"><span class="co">#&gt; 7      2018-01-10  20/01/2018 female          not a case</span></a>
+<a class="sourceLine" id="cb3-29" data-line-number="29"><span class="co">#&gt; 8      2018-01-06  16/01/2018   MALE            probable</span></a>
+<a class="sourceLine" id="cb3-30" data-line-number="30"><span class="co">#&gt; 9      2018-01-08  18/01/2018 Female            probable</span></a>
+<a class="sourceLine" id="cb3-31" data-line-number="31"><span class="co">#&gt; 10     2018-01-08  18/01/2018   MALE           Confirmed</span></a>
+<a class="sourceLine" id="cb3-32" data-line-number="32"><span class="co">#&gt; 11     2018-01-10  20/01/2018   Male            PROBABLE</span></a>
+<a class="sourceLine" id="cb3-33" data-line-number="33"><span class="co">#&gt; 12     2018-01-11  21/01/2018 Female          Not.a.Case</span></a>
+<a class="sourceLine" id="cb3-34" data-line-number="34"><span class="co">#&gt; 13     2018-01-09  19/01/2018   MALE           Confirmed</span></a>
+<a class="sourceLine" id="cb3-35" data-line-number="35"><span class="co">#&gt; 14     2018-01-10  20/01/2018 Female            PROBABLE</span></a>
+<a class="sourceLine" id="cb3-36" data-line-number="36"><span class="co">#&gt; 15     2018-01-10  20/01/2018 female           Confirmed</span></a>
+<a class="sourceLine" id="cb3-37" data-line-number="37"><span class="co">#&gt; 16     2018-01-09  19/01/2018 Female            PROBABLE</span></a>
+<a class="sourceLine" id="cb3-38" data-line-number="38"><span class="co">#&gt; 17     2018-01-06  16/01/2018   male          not a case</span></a>
+<a class="sourceLine" id="cb3-39" data-line-number="39"><span class="co">#&gt; 18     2018-01-09  19/01/2018   MALE            probable</span></a>
+<a class="sourceLine" id="cb3-40" data-line-number="40"><span class="co">#&gt; 19     2018-01-11  21/01/2018   male           suspected</span></a>
+<a class="sourceLine" id="cb3-41" data-line-number="41"><span class="co">#&gt; 20     2018-01-06  16/01/2018   Male           suspected</span></a>
 <a class="sourceLine" id="cb3-42" data-line-number="42"><span class="co">#&gt;           messy.dates</span></a>
 <a class="sourceLine" id="cb3-43" data-line-number="43"><span class="co">#&gt; 1                male</span></a>
-<a class="sourceLine" id="cb3-44" data-line-number="44"><span class="co">#&gt; 2          2018 10 19</span></a>
-<a class="sourceLine" id="cb3-45" data-line-number="45"><span class="co">#&gt; 3          2018-10-18</span></a>
-<a class="sourceLine" id="cb3-46" data-line-number="46"><span class="co">#&gt; 4              female</span></a>
-<a class="sourceLine" id="cb3-47" data-line-number="47"><span class="co">#&gt; 5                male</span></a>
-<a class="sourceLine" id="cb3-48" data-line-number="48"><span class="co">#&gt; 6                &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb3-49" data-line-number="49"><span class="co">#&gt; 7  that's 24/12/1989!</span></a>
-<a class="sourceLine" id="cb3-50" data-line-number="50"><span class="co">#&gt; 8          2018_10_17</span></a>
+<a class="sourceLine" id="cb3-44" data-line-number="44"><span class="co">#&gt; 2          01-12-2001</span></a>
+<a class="sourceLine" id="cb3-45" data-line-number="45"><span class="co">#&gt; 3              female</span></a>
+<a class="sourceLine" id="cb3-46" data-line-number="46"><span class="co">#&gt; 4          01-12-2001</span></a>
+<a class="sourceLine" id="cb3-47" data-line-number="47"><span class="co">#&gt; 5          2018_10_17</span></a>
+<a class="sourceLine" id="cb3-48" data-line-number="48"><span class="co">#&gt; 6     // 24//12//1989</span></a>
+<a class="sourceLine" id="cb3-49" data-line-number="49"><span class="co">#&gt; 7              female</span></a>
+<a class="sourceLine" id="cb3-50" data-line-number="50"><span class="co">#&gt; 8          2018-10-18</span></a>
 <a class="sourceLine" id="cb3-51" data-line-number="51"><span class="co">#&gt; 9          2018_10_17</span></a>
-<a class="sourceLine" id="cb3-52" data-line-number="52"><span class="co">#&gt; 10               male</span></a>
-<a class="sourceLine" id="cb3-53" data-line-number="53"><span class="co">#&gt; 11         01-12-2001</span></a>
-<a class="sourceLine" id="cb3-54" data-line-number="54"><span class="co">#&gt; 12         2018 10 19</span></a>
-<a class="sourceLine" id="cb3-55" data-line-number="55"><span class="co">#&gt; 13    // 24//12//1989</span></a>
-<a class="sourceLine" id="cb3-56" data-line-number="56"><span class="co">#&gt; 14         01-12-2001</span></a>
+<a class="sourceLine" id="cb3-52" data-line-number="52"><span class="co">#&gt; 10         2018-10-18</span></a>
+<a class="sourceLine" id="cb3-53" data-line-number="53"><span class="co">#&gt; 11         2018_10_17</span></a>
+<a class="sourceLine" id="cb3-54" data-line-number="54"><span class="co">#&gt; 12    // 24//12//1989</span></a>
+<a class="sourceLine" id="cb3-55" data-line-number="55"><span class="co">#&gt; 13               male</span></a>
+<a class="sourceLine" id="cb3-56" data-line-number="56"><span class="co">#&gt; 14 that's 24/12/1989!</span></a>
 <a class="sourceLine" id="cb3-57" data-line-number="57"><span class="co">#&gt; 15         2018 10 19</span></a>
 <a class="sourceLine" id="cb3-58" data-line-number="58"><span class="co">#&gt; 16         2018 10 19</span></a>
-<a class="sourceLine" id="cb3-59" data-line-number="59"><span class="co">#&gt; 17         2018-10-18</span></a>
-<a class="sourceLine" id="cb3-60" data-line-number="60"><span class="co">#&gt; 18    // 24//12//1989</span></a>
-<a class="sourceLine" id="cb3-61" data-line-number="61"><span class="co">#&gt; 19               male</span></a>
-<a class="sourceLine" id="cb3-62" data-line-number="62"><span class="co">#&gt; 20             female</span></a></code></pre></div>
+<a class="sourceLine" id="cb3-59" data-line-number="59"><span class="co">#&gt; 17             female</span></a>
+<a class="sourceLine" id="cb3-60" data-line-number="60"><span class="co">#&gt; 18               &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb3-61" data-line-number="61"><span class="co">#&gt; 19         2018_10_17</span></a>
+<a class="sourceLine" id="cb3-62" data-line-number="62"><span class="co">#&gt; 20    // 24//12//1989</span></a></code></pre></div>
 <p>We start by cleaning these data:</p>
 <div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1"><span class="co">## load library</span></a>
 <a class="sourceLine" id="cb4-2" data-line-number="2"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(linelist)</a>
@@ -216,26 +216,26 @@
 <a class="sourceLine" id="cb4-5" data-line-number="5">x &lt;-<span class="st"> </span><span class="kw"><a href="reference/clean_data.html">clean_data</a></span>(toy_data)</a>
 <a class="sourceLine" id="cb4-6" data-line-number="6">x</a>
 <a class="sourceLine" id="cb4-7" data-line-number="7"><span class="co">#&gt;    date_of_onset  discharge    sex epi_case_definition messy_dates</span></a>
-<a class="sourceLine" id="cb4-8" data-line-number="8"><span class="co">#&gt; 1     2018-01-11 2018-01-21 female           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-9" data-line-number="9"><span class="co">#&gt; 2     2018-01-11 2018-01-21 female            probable  2018-10-19</span></a>
-<a class="sourceLine" id="cb4-10" data-line-number="10"><span class="co">#&gt; 3     2018-01-03 2018-01-13 female            probable  2018-10-18</span></a>
-<a class="sourceLine" id="cb4-11" data-line-number="11"><span class="co">#&gt; 4     2018-01-02 2018-01-12   male           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-12" data-line-number="12"><span class="co">#&gt; 5     2018-01-04 2018-01-14 female           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-13" data-line-number="13"><span class="co">#&gt; 6     2018-01-06 2018-01-16 female           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-14" data-line-number="14"><span class="co">#&gt; 7     2018-01-07 2018-01-17   male           suspected  1989-12-24</span></a>
-<a class="sourceLine" id="cb4-15" data-line-number="15"><span class="co">#&gt; 8     2018-01-02 2018-01-12   male          not_a_case  2018-10-17</span></a>
-<a class="sourceLine" id="cb4-16" data-line-number="16"><span class="co">#&gt; 9     2018-01-04 2018-01-14 female           suspected  2018-10-17</span></a>
-<a class="sourceLine" id="cb4-17" data-line-number="17"><span class="co">#&gt; 10    2018-01-07 2018-01-17   male           confirmed        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-18" data-line-number="18"><span class="co">#&gt; 11    2018-01-10 2018-01-20 female          not_a_case  2001-12-01</span></a>
-<a class="sourceLine" id="cb4-19" data-line-number="19"><span class="co">#&gt; 12    2018-01-08 2018-01-18   male           confirmed  2018-10-19</span></a>
-<a class="sourceLine" id="cb4-20" data-line-number="20"><span class="co">#&gt; 13    2018-01-03 2018-01-13 female          not_a_case  1989-12-24</span></a>
-<a class="sourceLine" id="cb4-21" data-line-number="21"><span class="co">#&gt; 14    2018-01-10 2018-01-20 female           confirmed  2001-12-01</span></a>
-<a class="sourceLine" id="cb4-22" data-line-number="22"><span class="co">#&gt; 15    2018-01-11 2018-01-21 female          not_a_case  2018-10-19</span></a>
-<a class="sourceLine" id="cb4-23" data-line-number="23"><span class="co">#&gt; 16    2018-01-05 2018-01-15   male          not_a_case  2018-10-19</span></a>
-<a class="sourceLine" id="cb4-24" data-line-number="24"><span class="co">#&gt; 17    2018-01-08 2018-01-18 female           confirmed  2018-10-18</span></a>
-<a class="sourceLine" id="cb4-25" data-line-number="25"><span class="co">#&gt; 18    2018-01-04 2018-01-14 female            probable  1989-12-24</span></a>
-<a class="sourceLine" id="cb4-26" data-line-number="26"><span class="co">#&gt; 19    2018-01-09 2018-01-19   male           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb4-27" data-line-number="27"><span class="co">#&gt; 20    2018-01-11 2018-01-21   male           confirmed        &lt;NA&gt;</span></a></code></pre></div>
+<a class="sourceLine" id="cb4-8" data-line-number="8"><span class="co">#&gt; 1     2018-01-09 2018-01-19   male          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-9" data-line-number="9"><span class="co">#&gt; 2     2018-01-05 2018-01-15   male           suspected  2001-12-01</span></a>
+<a class="sourceLine" id="cb4-10" data-line-number="10"><span class="co">#&gt; 3     2018-01-02 2018-01-12 female          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-11" data-line-number="11"><span class="co">#&gt; 4     2018-01-07 2018-01-17 female           confirmed  2001-12-01</span></a>
+<a class="sourceLine" id="cb4-12" data-line-number="12"><span class="co">#&gt; 5     2018-01-09 2018-01-19   male            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb4-13" data-line-number="13"><span class="co">#&gt; 6     2018-01-05 2018-01-15 female           confirmed  1989-12-24</span></a>
+<a class="sourceLine" id="cb4-14" data-line-number="14"><span class="co">#&gt; 7     2018-01-10 2018-01-20 female          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-15" data-line-number="15"><span class="co">#&gt; 8     2018-01-06 2018-01-16   male            probable  2018-10-18</span></a>
+<a class="sourceLine" id="cb4-16" data-line-number="16"><span class="co">#&gt; 9     2018-01-08 2018-01-18 female            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb4-17" data-line-number="17"><span class="co">#&gt; 10    2018-01-08 2018-01-18   male           confirmed  2018-10-18</span></a>
+<a class="sourceLine" id="cb4-18" data-line-number="18"><span class="co">#&gt; 11    2018-01-10 2018-01-20   male            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb4-19" data-line-number="19"><span class="co">#&gt; 12    2018-01-11 2018-01-21 female          not_a_case  1989-12-24</span></a>
+<a class="sourceLine" id="cb4-20" data-line-number="20"><span class="co">#&gt; 13    2018-01-09 2018-01-19   male           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-21" data-line-number="21"><span class="co">#&gt; 14    2018-01-10 2018-01-20 female            probable  1989-12-24</span></a>
+<a class="sourceLine" id="cb4-22" data-line-number="22"><span class="co">#&gt; 15    2018-01-10 2018-01-20 female           confirmed  2018-10-19</span></a>
+<a class="sourceLine" id="cb4-23" data-line-number="23"><span class="co">#&gt; 16    2018-01-09 2018-01-19 female            probable  2018-10-19</span></a>
+<a class="sourceLine" id="cb4-24" data-line-number="24"><span class="co">#&gt; 17    2018-01-06 2018-01-16   male          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-25" data-line-number="25"><span class="co">#&gt; 18    2018-01-09 2018-01-19   male            probable        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb4-26" data-line-number="26"><span class="co">#&gt; 19    2018-01-11 2018-01-21   male           suspected  2018-10-17</span></a>
+<a class="sourceLine" id="cb4-27" data-line-number="27"><span class="co">#&gt; 20    2018-01-06 2018-01-16   male           suspected  1989-12-24</span></a></code></pre></div>
 <p>We can now define some <code>epivars</code> for <code>x</code>, i.e. identify which columns correspond to typical epidemiological variables:</p>
 <div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1"><span class="co">## see what the dictionary is</span></a>
 <a class="sourceLine" id="cb5-2" data-line-number="2"><span class="kw"><a href="reference/dictionary.html">get_dictionary</a></span>()</a>
@@ -276,26 +276,26 @@
 <a class="sourceLine" id="cb5-37" data-line-number="37"><span class="co">#&gt; &lt;linelist object&gt;</span></a>
 <a class="sourceLine" id="cb5-38" data-line-number="38"><span class="co">#&gt; </span></a>
 <a class="sourceLine" id="cb5-39" data-line-number="39"><span class="co">#&gt;    date_of_onset  discharge    sex epi_case_definition messy_dates</span></a>
-<a class="sourceLine" id="cb5-40" data-line-number="40"><span class="co">#&gt; 1     2018-01-11 2018-01-21 female           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-41" data-line-number="41"><span class="co">#&gt; 2     2018-01-11 2018-01-21 female            probable  2018-10-19</span></a>
-<a class="sourceLine" id="cb5-42" data-line-number="42"><span class="co">#&gt; 3     2018-01-03 2018-01-13 female            probable  2018-10-18</span></a>
-<a class="sourceLine" id="cb5-43" data-line-number="43"><span class="co">#&gt; 4     2018-01-02 2018-01-12   male           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-44" data-line-number="44"><span class="co">#&gt; 5     2018-01-04 2018-01-14 female           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-45" data-line-number="45"><span class="co">#&gt; 6     2018-01-06 2018-01-16 female           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-46" data-line-number="46"><span class="co">#&gt; 7     2018-01-07 2018-01-17   male           suspected  1989-12-24</span></a>
-<a class="sourceLine" id="cb5-47" data-line-number="47"><span class="co">#&gt; 8     2018-01-02 2018-01-12   male          not_a_case  2018-10-17</span></a>
-<a class="sourceLine" id="cb5-48" data-line-number="48"><span class="co">#&gt; 9     2018-01-04 2018-01-14 female           suspected  2018-10-17</span></a>
-<a class="sourceLine" id="cb5-49" data-line-number="49"><span class="co">#&gt; 10    2018-01-07 2018-01-17   male           confirmed        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-50" data-line-number="50"><span class="co">#&gt; 11    2018-01-10 2018-01-20 female          not_a_case  2001-12-01</span></a>
-<a class="sourceLine" id="cb5-51" data-line-number="51"><span class="co">#&gt; 12    2018-01-08 2018-01-18   male           confirmed  2018-10-19</span></a>
-<a class="sourceLine" id="cb5-52" data-line-number="52"><span class="co">#&gt; 13    2018-01-03 2018-01-13 female          not_a_case  1989-12-24</span></a>
-<a class="sourceLine" id="cb5-53" data-line-number="53"><span class="co">#&gt; 14    2018-01-10 2018-01-20 female           confirmed  2001-12-01</span></a>
-<a class="sourceLine" id="cb5-54" data-line-number="54"><span class="co">#&gt; 15    2018-01-11 2018-01-21 female          not_a_case  2018-10-19</span></a>
-<a class="sourceLine" id="cb5-55" data-line-number="55"><span class="co">#&gt; 16    2018-01-05 2018-01-15   male          not_a_case  2018-10-19</span></a>
-<a class="sourceLine" id="cb5-56" data-line-number="56"><span class="co">#&gt; 17    2018-01-08 2018-01-18 female           confirmed  2018-10-18</span></a>
-<a class="sourceLine" id="cb5-57" data-line-number="57"><span class="co">#&gt; 18    2018-01-04 2018-01-14 female            probable  1989-12-24</span></a>
-<a class="sourceLine" id="cb5-58" data-line-number="58"><span class="co">#&gt; 19    2018-01-09 2018-01-19   male           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb5-59" data-line-number="59"><span class="co">#&gt; 20    2018-01-11 2018-01-21   male           confirmed        &lt;NA&gt;</span></a></code></pre></div>
+<a class="sourceLine" id="cb5-40" data-line-number="40"><span class="co">#&gt; 1     2018-01-09 2018-01-19   male          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-41" data-line-number="41"><span class="co">#&gt; 2     2018-01-05 2018-01-15   male           suspected  2001-12-01</span></a>
+<a class="sourceLine" id="cb5-42" data-line-number="42"><span class="co">#&gt; 3     2018-01-02 2018-01-12 female          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-43" data-line-number="43"><span class="co">#&gt; 4     2018-01-07 2018-01-17 female           confirmed  2001-12-01</span></a>
+<a class="sourceLine" id="cb5-44" data-line-number="44"><span class="co">#&gt; 5     2018-01-09 2018-01-19   male            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb5-45" data-line-number="45"><span class="co">#&gt; 6     2018-01-05 2018-01-15 female           confirmed  1989-12-24</span></a>
+<a class="sourceLine" id="cb5-46" data-line-number="46"><span class="co">#&gt; 7     2018-01-10 2018-01-20 female          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-47" data-line-number="47"><span class="co">#&gt; 8     2018-01-06 2018-01-16   male            probable  2018-10-18</span></a>
+<a class="sourceLine" id="cb5-48" data-line-number="48"><span class="co">#&gt; 9     2018-01-08 2018-01-18 female            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb5-49" data-line-number="49"><span class="co">#&gt; 10    2018-01-08 2018-01-18   male           confirmed  2018-10-18</span></a>
+<a class="sourceLine" id="cb5-50" data-line-number="50"><span class="co">#&gt; 11    2018-01-10 2018-01-20   male            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb5-51" data-line-number="51"><span class="co">#&gt; 12    2018-01-11 2018-01-21 female          not_a_case  1989-12-24</span></a>
+<a class="sourceLine" id="cb5-52" data-line-number="52"><span class="co">#&gt; 13    2018-01-09 2018-01-19   male           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-53" data-line-number="53"><span class="co">#&gt; 14    2018-01-10 2018-01-20 female            probable  1989-12-24</span></a>
+<a class="sourceLine" id="cb5-54" data-line-number="54"><span class="co">#&gt; 15    2018-01-10 2018-01-20 female           confirmed  2018-10-19</span></a>
+<a class="sourceLine" id="cb5-55" data-line-number="55"><span class="co">#&gt; 16    2018-01-09 2018-01-19 female            probable  2018-10-19</span></a>
+<a class="sourceLine" id="cb5-56" data-line-number="56"><span class="co">#&gt; 17    2018-01-06 2018-01-16   male          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-57" data-line-number="57"><span class="co">#&gt; 18    2018-01-09 2018-01-19   male            probable        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb5-58" data-line-number="58"><span class="co">#&gt; 19    2018-01-11 2018-01-21   male           suspected  2018-10-17</span></a>
+<a class="sourceLine" id="cb5-59" data-line-number="59"><span class="co">#&gt; 20    2018-01-06 2018-01-16   male           suspected  1989-12-24</span></a></code></pre></div>
 <p>Note that the equivalent can be done using piping:</p>
 <div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1"><span class="kw"><a href="https://www.rdocumentation.org/packages/base/topics/library">library</a></span>(magrittr)</a>
 <a class="sourceLine" id="cb6-2" data-line-number="2">x &lt;-<span class="st"> </span>toy_data <span class="op">%&gt;%</span></a>
@@ -305,26 +305,26 @@
 <a class="sourceLine" id="cb6-6" data-line-number="6"><span class="co">#&gt; &lt;linelist object&gt;</span></a>
 <a class="sourceLine" id="cb6-7" data-line-number="7"><span class="co">#&gt; </span></a>
 <a class="sourceLine" id="cb6-8" data-line-number="8"><span class="co">#&gt;    date_of_onset  discharge    sex epi_case_definition messy_dates</span></a>
-<a class="sourceLine" id="cb6-9" data-line-number="9"><span class="co">#&gt; 1     2018-01-11 2018-01-21 female           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-10" data-line-number="10"><span class="co">#&gt; 2     2018-01-11 2018-01-21 female            probable  2018-10-19</span></a>
-<a class="sourceLine" id="cb6-11" data-line-number="11"><span class="co">#&gt; 3     2018-01-03 2018-01-13 female            probable  2018-10-18</span></a>
-<a class="sourceLine" id="cb6-12" data-line-number="12"><span class="co">#&gt; 4     2018-01-02 2018-01-12   male           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-13" data-line-number="13"><span class="co">#&gt; 5     2018-01-04 2018-01-14 female           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-14" data-line-number="14"><span class="co">#&gt; 6     2018-01-06 2018-01-16 female           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-15" data-line-number="15"><span class="co">#&gt; 7     2018-01-07 2018-01-17   male           suspected  1989-12-24</span></a>
-<a class="sourceLine" id="cb6-16" data-line-number="16"><span class="co">#&gt; 8     2018-01-02 2018-01-12   male          not_a_case  2018-10-17</span></a>
-<a class="sourceLine" id="cb6-17" data-line-number="17"><span class="co">#&gt; 9     2018-01-04 2018-01-14 female           suspected  2018-10-17</span></a>
-<a class="sourceLine" id="cb6-18" data-line-number="18"><span class="co">#&gt; 10    2018-01-07 2018-01-17   male           confirmed        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-19" data-line-number="19"><span class="co">#&gt; 11    2018-01-10 2018-01-20 female          not_a_case  2001-12-01</span></a>
-<a class="sourceLine" id="cb6-20" data-line-number="20"><span class="co">#&gt; 12    2018-01-08 2018-01-18   male           confirmed  2018-10-19</span></a>
-<a class="sourceLine" id="cb6-21" data-line-number="21"><span class="co">#&gt; 13    2018-01-03 2018-01-13 female          not_a_case  1989-12-24</span></a>
-<a class="sourceLine" id="cb6-22" data-line-number="22"><span class="co">#&gt; 14    2018-01-10 2018-01-20 female           confirmed  2001-12-01</span></a>
-<a class="sourceLine" id="cb6-23" data-line-number="23"><span class="co">#&gt; 15    2018-01-11 2018-01-21 female          not_a_case  2018-10-19</span></a>
-<a class="sourceLine" id="cb6-24" data-line-number="24"><span class="co">#&gt; 16    2018-01-05 2018-01-15   male          not_a_case  2018-10-19</span></a>
-<a class="sourceLine" id="cb6-25" data-line-number="25"><span class="co">#&gt; 17    2018-01-08 2018-01-18 female           confirmed  2018-10-18</span></a>
-<a class="sourceLine" id="cb6-26" data-line-number="26"><span class="co">#&gt; 18    2018-01-04 2018-01-14 female            probable  1989-12-24</span></a>
-<a class="sourceLine" id="cb6-27" data-line-number="27"><span class="co">#&gt; 19    2018-01-09 2018-01-19   male           suspected        &lt;NA&gt;</span></a>
-<a class="sourceLine" id="cb6-28" data-line-number="28"><span class="co">#&gt; 20    2018-01-11 2018-01-21   male           confirmed        &lt;NA&gt;</span></a></code></pre></div>
+<a class="sourceLine" id="cb6-9" data-line-number="9"><span class="co">#&gt; 1     2018-01-09 2018-01-19   male          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-10" data-line-number="10"><span class="co">#&gt; 2     2018-01-05 2018-01-15   male           suspected  2001-12-01</span></a>
+<a class="sourceLine" id="cb6-11" data-line-number="11"><span class="co">#&gt; 3     2018-01-02 2018-01-12 female          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-12" data-line-number="12"><span class="co">#&gt; 4     2018-01-07 2018-01-17 female           confirmed  2001-12-01</span></a>
+<a class="sourceLine" id="cb6-13" data-line-number="13"><span class="co">#&gt; 5     2018-01-09 2018-01-19   male            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb6-14" data-line-number="14"><span class="co">#&gt; 6     2018-01-05 2018-01-15 female           confirmed  1989-12-24</span></a>
+<a class="sourceLine" id="cb6-15" data-line-number="15"><span class="co">#&gt; 7     2018-01-10 2018-01-20 female          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-16" data-line-number="16"><span class="co">#&gt; 8     2018-01-06 2018-01-16   male            probable  2018-10-18</span></a>
+<a class="sourceLine" id="cb6-17" data-line-number="17"><span class="co">#&gt; 9     2018-01-08 2018-01-18 female            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb6-18" data-line-number="18"><span class="co">#&gt; 10    2018-01-08 2018-01-18   male           confirmed  2018-10-18</span></a>
+<a class="sourceLine" id="cb6-19" data-line-number="19"><span class="co">#&gt; 11    2018-01-10 2018-01-20   male            probable  2018-10-17</span></a>
+<a class="sourceLine" id="cb6-20" data-line-number="20"><span class="co">#&gt; 12    2018-01-11 2018-01-21 female          not_a_case  1989-12-24</span></a>
+<a class="sourceLine" id="cb6-21" data-line-number="21"><span class="co">#&gt; 13    2018-01-09 2018-01-19   male           confirmed        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-22" data-line-number="22"><span class="co">#&gt; 14    2018-01-10 2018-01-20 female            probable  1989-12-24</span></a>
+<a class="sourceLine" id="cb6-23" data-line-number="23"><span class="co">#&gt; 15    2018-01-10 2018-01-20 female           confirmed  2018-10-19</span></a>
+<a class="sourceLine" id="cb6-24" data-line-number="24"><span class="co">#&gt; 16    2018-01-09 2018-01-19 female            probable  2018-10-19</span></a>
+<a class="sourceLine" id="cb6-25" data-line-number="25"><span class="co">#&gt; 17    2018-01-06 2018-01-16   male          not_a_case        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-26" data-line-number="26"><span class="co">#&gt; 18    2018-01-09 2018-01-19   male            probable        &lt;NA&gt;</span></a>
+<a class="sourceLine" id="cb6-27" data-line-number="27"><span class="co">#&gt; 19    2018-01-11 2018-01-21   male           suspected  2018-10-17</span></a>
+<a class="sourceLine" id="cb6-28" data-line-number="28"><span class="co">#&gt; 20    2018-01-06 2018-01-16   male           suspected  1989-12-24</span></a></code></pre></div>
 <p>We now handle a clean dataset, with standardised labels and variable names, and dates of onset and gender are now formally identifier:</p>
 <div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1"><span class="co">## check available epivars</span></a>
 <a class="sourceLine" id="cb7-2" data-line-number="2"><span class="kw"><a href="reference/list_epivars.html">list_epivars</a></span>(x, <span class="dt">simple =</span> <span class="ot">TRUE</span>) <span class="co"># simple</span></a>
@@ -337,26 +337,26 @@
 <a class="sourceLine" id="cb7-9" data-line-number="9"></a>
 <a class="sourceLine" id="cb7-10" data-line-number="10"><span class="kw"><a href="reference/accessors.html">get_epivars</a></span>(x, <span class="st">"gender"</span>, <span class="st">"date_onset"</span>)</a>
 <a class="sourceLine" id="cb7-11" data-line-number="11"><span class="co">#&gt;       sex date_of_onset</span></a>
-<a class="sourceLine" id="cb7-12" data-line-number="12"><span class="co">#&gt; 1  female    2018-01-11</span></a>
-<a class="sourceLine" id="cb7-13" data-line-number="13"><span class="co">#&gt; 2  female    2018-01-11</span></a>
-<a class="sourceLine" id="cb7-14" data-line-number="14"><span class="co">#&gt; 3  female    2018-01-03</span></a>
-<a class="sourceLine" id="cb7-15" data-line-number="15"><span class="co">#&gt; 4    male    2018-01-02</span></a>
-<a class="sourceLine" id="cb7-16" data-line-number="16"><span class="co">#&gt; 5  female    2018-01-04</span></a>
-<a class="sourceLine" id="cb7-17" data-line-number="17"><span class="co">#&gt; 6  female    2018-01-06</span></a>
-<a class="sourceLine" id="cb7-18" data-line-number="18"><span class="co">#&gt; 7    male    2018-01-07</span></a>
-<a class="sourceLine" id="cb7-19" data-line-number="19"><span class="co">#&gt; 8    male    2018-01-02</span></a>
-<a class="sourceLine" id="cb7-20" data-line-number="20"><span class="co">#&gt; 9  female    2018-01-04</span></a>
-<a class="sourceLine" id="cb7-21" data-line-number="21"><span class="co">#&gt; 10   male    2018-01-07</span></a>
-<a class="sourceLine" id="cb7-22" data-line-number="22"><span class="co">#&gt; 11 female    2018-01-10</span></a>
-<a class="sourceLine" id="cb7-23" data-line-number="23"><span class="co">#&gt; 12   male    2018-01-08</span></a>
-<a class="sourceLine" id="cb7-24" data-line-number="24"><span class="co">#&gt; 13 female    2018-01-03</span></a>
+<a class="sourceLine" id="cb7-12" data-line-number="12"><span class="co">#&gt; 1    male    2018-01-09</span></a>
+<a class="sourceLine" id="cb7-13" data-line-number="13"><span class="co">#&gt; 2    male    2018-01-05</span></a>
+<a class="sourceLine" id="cb7-14" data-line-number="14"><span class="co">#&gt; 3  female    2018-01-02</span></a>
+<a class="sourceLine" id="cb7-15" data-line-number="15"><span class="co">#&gt; 4  female    2018-01-07</span></a>
+<a class="sourceLine" id="cb7-16" data-line-number="16"><span class="co">#&gt; 5    male    2018-01-09</span></a>
+<a class="sourceLine" id="cb7-17" data-line-number="17"><span class="co">#&gt; 6  female    2018-01-05</span></a>
+<a class="sourceLine" id="cb7-18" data-line-number="18"><span class="co">#&gt; 7  female    2018-01-10</span></a>
+<a class="sourceLine" id="cb7-19" data-line-number="19"><span class="co">#&gt; 8    male    2018-01-06</span></a>
+<a class="sourceLine" id="cb7-20" data-line-number="20"><span class="co">#&gt; 9  female    2018-01-08</span></a>
+<a class="sourceLine" id="cb7-21" data-line-number="21"><span class="co">#&gt; 10   male    2018-01-08</span></a>
+<a class="sourceLine" id="cb7-22" data-line-number="22"><span class="co">#&gt; 11   male    2018-01-10</span></a>
+<a class="sourceLine" id="cb7-23" data-line-number="23"><span class="co">#&gt; 12 female    2018-01-11</span></a>
+<a class="sourceLine" id="cb7-24" data-line-number="24"><span class="co">#&gt; 13   male    2018-01-09</span></a>
 <a class="sourceLine" id="cb7-25" data-line-number="25"><span class="co">#&gt; 14 female    2018-01-10</span></a>
-<a class="sourceLine" id="cb7-26" data-line-number="26"><span class="co">#&gt; 15 female    2018-01-11</span></a>
-<a class="sourceLine" id="cb7-27" data-line-number="27"><span class="co">#&gt; 16   male    2018-01-05</span></a>
-<a class="sourceLine" id="cb7-28" data-line-number="28"><span class="co">#&gt; 17 female    2018-01-08</span></a>
-<a class="sourceLine" id="cb7-29" data-line-number="29"><span class="co">#&gt; 18 female    2018-01-04</span></a>
-<a class="sourceLine" id="cb7-30" data-line-number="30"><span class="co">#&gt; 19   male    2018-01-09</span></a>
-<a class="sourceLine" id="cb7-31" data-line-number="31"><span class="co">#&gt; 20   male    2018-01-11</span></a></code></pre></div>
+<a class="sourceLine" id="cb7-26" data-line-number="26"><span class="co">#&gt; 15 female    2018-01-10</span></a>
+<a class="sourceLine" id="cb7-27" data-line-number="27"><span class="co">#&gt; 16 female    2018-01-09</span></a>
+<a class="sourceLine" id="cb7-28" data-line-number="28"><span class="co">#&gt; 17   male    2018-01-06</span></a>
+<a class="sourceLine" id="cb7-29" data-line-number="29"><span class="co">#&gt; 18   male    2018-01-09</span></a>
+<a class="sourceLine" id="cb7-30" data-line-number="30"><span class="co">#&gt; 19   male    2018-01-11</span></a>
+<a class="sourceLine" id="cb7-31" data-line-number="31"><span class="co">#&gt; 20   male    2018-01-06</span></a></code></pre></div>
 <div id="getting-help-online" class="section level2">
 <h2 class="hasAnchor">
 <a href="#getting-help-online" class="anchor"></a>Getting help online</h2>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -123,6 +123,8 @@
 <code><a href="../reference/guess_dates.html">guess_dates()</a></code> now processes at double the speed of the previous version.</li>
 <li>
 <code><a href="../reference/guess_dates.html">guess_dates()</a></code> will now properly constrain date vectors to the start and end dates.</li>
+<li>
+<code><a href="../reference/guess_dates.html">guess_dates()</a></code> correctly parses dates represented as integers from excel (<a href='https://github.com/reconhub/linelist/issues/73'>#73</a>).</li>
 </ul>
 </div>
     <div id="linelist-0-0-32-9000" class="section level1">

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 
@@ -115,6 +115,16 @@
       <small>Source: <a href='https://github.com/reconhub/linelist/blob/master/NEWS.md'><code>NEWS.md</code></a></small>
     </div>
 
+    <div id="linelist-0-0-33-9000" class="section level1">
+<h1 class="page-header">
+<a href="#linelist-0-0-33-9000" class="anchor"></a>linelist 0.0.33.9000</h1>
+<ul>
+<li>
+<code><a href="../reference/guess_dates.html">guess_dates()</a></code> now processes at double the speed of the previous version.</li>
+<li>
+<code><a href="../reference/guess_dates.html">guess_dates()</a></code> will now properly constrain date vectors to the start and end dates.</li>
+</ul>
+</div>
     <div id="linelist-0-0-32-9000" class="section level1">
 <h1 class="page-header">
 <a href="#linelist-0-0-32-9000" class="anchor"></a>linelist 0.0.32.9000</h1>
@@ -394,6 +404,7 @@
     <div id="tocnav">
       <h2>Contents</h2>
       <ul class="nav nav-pills nav-stacked">
+        <li><a href="#linelist-0-0-33-9000">0.0.33.9000</a></li>
         <li><a href="#linelist-0-0-32-9000">0.0.32.9000</a></li>
         <li><a href="#linelist-0-0-31-9000">0.0.31.9000</a></li>
         <li><a href="#linelist-0-0-30-9000">0.0.30.9000</a></li>

--- a/docs/reference/accessors.html
+++ b/docs/reference/accessors.html
@@ -64,7 +64,7 @@ epivars in your linelist object." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/add_epivar.html
+++ b/docs/reference/add_epivar.html
@@ -64,7 +64,7 @@ user to add rows to the dictionary." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/as.data.frame.linelist.html
+++ b/docs/reference/as.data.frame.linelist.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/as_linelist.html
+++ b/docs/reference/as_linelist.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/clean_data.html
+++ b/docs/reference/clean_data.html
@@ -67,7 +67,7 @@ from various formats mixed with other text. See details for more information." /
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/clean_dates.html
+++ b/docs/reference/clean_dates.html
@@ -72,7 +72,7 @@ to be a date, and left untouched." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/clean_spelling.html
+++ b/docs/reference/clean_spelling.html
@@ -65,7 +65,7 @@ a data wordlist can be imported from a data frame." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/clean_variable_labels.html
+++ b/docs/reference/clean_variable_labels.html
@@ -66,7 +66,7 @@ epitrix::clean_labels() in the epitrix package. See
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/clean_variable_names.html
+++ b/docs/reference/clean_variable_names.html
@@ -66,7 +66,7 @@ epitrix::clean_labels() in the epitrix package. See
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/clean_variable_spelling.html
+++ b/docs/reference/clean_variable_spelling.html
@@ -66,7 +66,7 @@ from electronic survey data)." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/clean_variables.html
+++ b/docs/reference/clean_variables.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/compare_data.html
+++ b/docs/reference/compare_data.html
@@ -64,7 +64,7 @@ issuing a series of diagnostics." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/dictionary.html
+++ b/docs/reference/dictionary.html
@@ -75,7 +75,7 @@ is a wrapper for options(linelist_epivars = ...)." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/get_structure.html
+++ b/docs/reference/get_structure.html
@@ -64,7 +64,7 @@ the following information:" />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/guess_dates.html
+++ b/docs/reference/guess_dates.html
@@ -71,7 +71,7 @@ threshold is exceeded, the original vector is returned." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/guess_dates.html
+++ b/docs/reference/guess_dates.html
@@ -288,16 +288,16 @@ situation.
 <span class='co'># guess_dates can handle messy dates and tolerate missing data</span>
 
 <span class='no'>x</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://www.rdocumentation.org/packages/base/topics/c'>c</a></span>(<span class='st'>"01-12-2001"</span>, <span class='st'>"male"</span>, <span class='st'>"female"</span>, <span class='st'>"2018-10-18"</span>, <span class='fl'>NA</span>, <span class='fl'>NA</span>, <span class='st'>"2018_10_17"</span>,
-      <span class='st'>"43387"</span>, <span class='st'>"2018 10 19"</span>, <span class='st'>"// 24/12/1989"</span>, <span class='st'>"this is 24/12/1989!"</span>,
-      <span class='st'>"RECON NGO: 19 Sep 2018 :)"</span>, <span class='st'>"6/9/11"</span>, <span class='st'>"10/10/10"</span>)
+       <span class='st'>"43391"</span>, <span class='st'>"2018 10 19"</span>, <span class='st'>"// 24/12/1989"</span>, <span class='st'>"this is 24/12/1989!"</span>,
+       <span class='st'>"RECON NGO: 19 Sep 2018 :)"</span>, <span class='st'>"6/9/11"</span>, <span class='st'>"10/10/10"</span>)
 
 <span class='fu'>guess_dates</span>(<span class='no'>x</span>, <span class='kw'>error_tolerance</span> <span class='kw'>=</span> <span class='fl'>1</span>) <span class='co'># forced conversion</span></div><div class='output co'>#&gt;  [1] "2001-12-01" NA           NA           "2018-10-18" NA          
-#&gt;  [6] NA           "2018-10-17" "2018-10-16" "2018-10-19" "1989-12-24"
+#&gt;  [6] NA           "2018-10-17" "2018-10-18" "2018-10-19" "1989-12-24"
 #&gt; [11] "1989-12-24" "2018-09-19" "2011-09-06" "2010-10-10"</div><div class='input'>
 <span class='fu'>guess_dates</span>(<span class='no'>x</span>, <span class='kw'>error_tolerance</span> <span class='kw'>=</span> <span class='fl'>0.15</span>) <span class='co'># only 15% errors allowed</span></div><div class='output co'>#&gt;  [1] "01-12-2001"                "male"                     
 #&gt;  [3] "female"                    "2018-10-18"               
 #&gt;  [5] NA                          NA                         
-#&gt;  [7] "2018_10_17"                "43387"                    
+#&gt;  [7] "2018_10_17"                "43391"                    
 #&gt;  [9] "2018 10 19"                "// 24/12/1989"            
 #&gt; [11] "this is 24/12/1989!"       "RECON NGO: 19 Sep 2018 :)"
 #&gt; [13] "6/9/11"                    "10/10/10"                 </div><div class='input'>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -60,7 +60,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/list_epivars.html
+++ b/docs/reference/list_epivars.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/lookup.html
+++ b/docs/reference/lookup.html
@@ -65,7 +65,7 @@ in your data set." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/mask.html
+++ b/docs/reference/mask.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/messy_data.html
+++ b/docs/reference/messy_data.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/print.linelist.html
+++ b/docs/reference/print.linelist.html
@@ -64,7 +64,7 @@ the variables." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/set_epivars.html
+++ b/docs/reference/set_epivars.html
@@ -64,7 +64,7 @@ object." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/template_linelist.html
+++ b/docs/reference/template_linelist.html
@@ -63,7 +63,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/docs/reference/top_values.html
+++ b/docs/reference/top_values.html
@@ -67,7 +67,7 @@ and forcats::fct_recode()." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">linelist</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.32.9000</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="Released version">0.0.33.9000</span>
       </span>
     </div>
 

--- a/man/guess_dates.Rd
+++ b/man/guess_dates.Rd
@@ -128,8 +128,8 @@ guess_dates(c("2014_04_05_23:15:43", "03 Jan 2018", "07/03/1982", "08/20/85"), o
 # guess_dates can handle messy dates and tolerate missing data
 
 x <- c("01-12-2001", "male", "female", "2018-10-18", NA, NA, "2018_10_17",
-      "43387", "2018 10 19", "// 24/12/1989", "this is 24/12/1989!",
-      "RECON NGO: 19 Sep 2018 :)", "6/9/11", "10/10/10")
+       "43391", "2018 10 19", "// 24/12/1989", "this is 24/12/1989!",
+       "RECON NGO: 19 Sep 2018 :)", "6/9/11", "10/10/10")
 
 guess_dates(x, error_tolerance = 1) # forced conversion
 

--- a/tests/testthat/test-guess_dates.R
+++ b/tests/testthat/test-guess_dates.R
@@ -39,6 +39,9 @@ test_that("date input requires no guesswork", {
   expect_identical(guess_dates(as.POSIXlt(expected_result)), expected_result)
   expect_identical(guess_dates(as.POSIXct(expected_result)), expected_result)
 
+  er <- c(expected_result, as.Date(NA_character_))
+  expect_identical(guess_dates(c(expected_result, Sys.Date() + 10)), er)
+
 })
 
 test_that("American dates also work", { 

--- a/tests/testthat/test-guess_dates.R
+++ b/tests/testthat/test-guess_dates.R
@@ -24,7 +24,7 @@ test_that("mixed formats work", {
 test_that("excel dates work", {
 
   xl <- x
-  xl[1:2] <- expected_result[1:2] - as.Date("1900-01-01")
+  xl[1:2] <- expected_result[1:2] - as.Date("1899-12-30")
   expect_equal(guess_dates(xl, error_tolerance = 0.8, first_date = as.Date("1980-01-01")),
                expected_result)
   xl[1:2] <- expected_result[1:2] - as.Date("1904-01-01")


### PR DESCRIPTION
This refactors and speeds up guess_dates. Now, instead of taking 2.5 seconds for 5K messy date entries, it takes 1.25 seconds. It's still not phenomenally fast, but it's faster and that's what matters.

This also changes the excel argument from a logical to a character, but the default will work the same.

The old version was slow:

```r
remotes::install_github("reconhub/linelist@0e6ac439963714ee0ca17a99237f554f6c183b6d")
library(linelist)
md <- messy_data(10000)$"messy/dates"
system.time(guess_dates(md, err = 1))
#>    user  system elapsed 
#>   3.530   0.076   3.605
```

By contrast, the new version doubles the speed.

``` r
remotes::install_github("reconhub/linelist@00f0e3db9d4264aea4bdccc2bccb85c9b4e72227")
library(linelist)
md <- messy_data(10000)$"messy/dates"
system.time(guess_dates(md, err = 1))
#>    user  system elapsed 
#>   1.714   0.092   1.806
```

<sup>Created on 2019-05-15 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

It now also has arguments for excel dates that include old windows (which addresses #73).
