### PR TITLE
add .regex keyword to clean_spelling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# linelist 0.0.34.9000
+
+* `clean_spelling()` now gains the `.regex ` keyword that allows the user to
+  supply perl-style regular expressions to change words that may have similar
+  spelling.
+
 # linelist 0.0.33.9000
 
 * `guess_dates()` now processes at double the speed of the previous version.

--- a/tests/testthat/test-clean_spelling.R
+++ b/tests/testthat/test-clean_spelling.R
@@ -29,6 +29,22 @@ test_that("clean_spelling throws an error with no wordlist", {
 
 })
 
+test_that("regex is possible", {
+
+  datf <- corrections
+  datf <- datf[2:5, ]
+  # replace foobar, foubar, foobr, fubar, etc with foobar
+  datf$bad[1]  <- ".regex ^f[ou][^m].+r$"
+  datf$good[1] <- "foobar"
+  
+  # replace the literal no importa with dang (shouldn't do anything)
+  datf$bad[2]  <- ".regex no importa"
+  datf$good[2] <- "dang"
+  expect_identical(clean_spelling(my_data, datf), cleaned_data)
+
+
+})
+
 test_that("logical values can be coerced", {
 
   res <- clean_spelling(1:5 > 2, data.frame(a = c(FALSE, TRUE), b = c("hell", "yeah")))


### PR DESCRIPTION
This addresses @thibautjombart's private issue that clean_spelling needs regex capabilities. Here is the solution:

``` r
library("linelist")
# create some fake data
my_data <- c(letters[1:5], "foubar", "foobr", "fubar", NA, "", "unknown", "fumar")
cleaned_data <- c(letters[1:5], "foobar", "foobar", "foobar", "missing", "missing", "missing", "fumar")


# You can use regular expressions to simplify your list
corrections <- data.frame(
  bad =  c(".regex f[ou][^m].+?r$", "unknown", ".missing"), 
  good = c("foobar",                ".na",     "missing"),
  stringsAsFactors = FALSE
)

corrections
#>                     bad    good
#> 1 .regex f[ou][^m].+?r$  foobar
#> 2               unknown     .na
#> 3              .missing missing
data.frame(original = my_data, cleaned = clean_spelling(my_data, corrections))
#>    original cleaned
#> 1         a       a
#> 2         b       b
#> 3         c       c
#> 4         d       d
#> 5         e       e
#> 6    foubar  foobar
#> 7     foobr  foobar
#> 8     fubar  foobar
#> 9      <NA> missing
#> 10          missing
#> 11  unknown    <NA>
#> 12    fumar   fumar
```

<sup>Created on 2019-05-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>