### PR TITLE
Regex boundaries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: linelist
 Title: Tools to Import and Tidy Case Linelist Data
-Version: 0.0.33.9000
+Version: 0.0.35.9000
 Authors@R: c(person("Thibaut", "Jombart", email = "thibautjombart@gmail.com", role = c("aut", "cre")),
     person("Zhian N.", "Kamvar", email = "zkamvar@gmail.com", role = c("aut")))
 Description: A collection of wrappers for importing case linelist data from usual formats, and tools for cleaning data, detecting dates, and storing meta-information on the content of the resulting data frame.  

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# linelist 0.0.35.9000
+
+* `clean_spelling()` gains the `anchor_regex` argument, which will wrap all
+  regex keyword entries in "^" and "$" before processing. 
+
 # linelist 0.0.34.9000
 
 * `clean_spelling()` now gains the `.regex ` keyword that allows the user to

--- a/R/clean_spelling.R
+++ b/R/clean_spelling.R
@@ -172,12 +172,13 @@ clean_spelling <- function(x = character(), wordlist = data.frame(),
 
   if (!quiet) {
     the_call  <- match.call()
-    no_keys   <- !any(x %in% keys, na.rm = TRUE)
+    no_regex  <- !any(grepl("^\\.regex ", keys))
+    no_keys   <- !any(x %in% keys, na.rm = TRUE) 
     no_values <- !any(x %in% values, na.rm = TRUE)
     the_x     <- deparse(the_call[["x"]])
     the_words <- deparse(the_call[["wordlist"]])
 
-    if (no_keys && no_values) {
+    if (no_keys && no_values && no_regex) {
       msg <- "None of the variables in %s were found in %s. Did you use the correct wordlist?" 
       msg <- sprintf(msg, the_x, the_words)
       warning(msg)

--- a/R/clean_spelling.R
+++ b/R/clean_spelling.R
@@ -19,6 +19,9 @@
 #'   that were changed to the default value. This can be used to update your
 #'   wordlist.
 #' 
+#' @param anchor_regex a `logical`. When `TRUE` (default), any regex within
+#'   the keywork 
+#' 
 #'
 #' @details 
 #'
@@ -28,8 +31,10 @@
 #' match in your current data set. These are expected to match exactly with
 #' the exception of three reserved keywords that start with a full stop:
 #'
-#'  - `.regex [pattern]`: will replace anything matching [pattern]. **This
-#'    is executed before any other replacements are made**
+#'  - `.regex [pattern]`: will replace anything matching `[pattern]`. **This
+#'    is executed before any other replacements are made**. The `[pattern]`
+#'    should be an unquoted, valid, PERL-flavored regular expression. Any
+#'    whitespace padding the regular expression is discarded.
 #'  - `.missing`: replaces any missing values (see NOTE)
 #'  - `.default`: replaces **ALL** values that are not defined in the wordlist
 #'                and are not missing. 
@@ -116,7 +121,8 @@
 #' @importFrom rlang "!!!"
 
 clean_spelling <- function(x = character(), wordlist = data.frame(),
-                           quiet = FALSE, warn_default = TRUE) {
+                           quiet = FALSE, warn_default = TRUE,
+                           anchor_regex = TRUE) {
 
   if (length(x) == 0 || !is.atomic(x)) {
     stop("x must be coerceable to a character")
@@ -206,7 +212,11 @@ clean_spelling <- function(x = character(), wordlist = data.frame(),
 
   # replacing regex keys first ------------------------------------------------
   reg_keys       <- grepl("^\\.regex ", dict)
-  dict[reg_keys] <-  gsub("^\\.regex ", "", dict[reg_keys])
+  dict[reg_keys] <- trimws(gsub("^\\.regex ", "", dict[reg_keys]))
+  # If the user wants us to automatically add regex anchors.
+  if (anchor_regex) {
+    dict[reg_keys] <- sprintf("^%s$", dict[reg_keys])
+  }
 
   for (i in seq_along(dict[reg_keys])) {
     pattern      <- dict[reg_keys][i] 

--- a/man/clean_spelling.Rd
+++ b/man/clean_spelling.Rd
@@ -5,7 +5,7 @@
 \title{Rename values in a vector based on a wordlist}
 \usage{
 clean_spelling(x = character(), wordlist = data.frame(),
-  quiet = FALSE, warn_default = TRUE)
+  quiet = FALSE, warn_default = TRUE, anchor_regex = TRUE)
 }
 \arguments{
 \item{x}{a character or factor vector}
@@ -22,6 +22,9 @@ replacement is made; if \code{FALSE}, these warnings will be disabled}
 \code{warn_default = TRUE}, a warning will be issued listing the variables
 that were changed to the default value. This can be used to update your
 wordlist.}
+
+\item{anchor_regex}{a \code{logical}. When \code{TRUE} (default), any regex within
+the keywork}
 }
 \value{
 a vector of the same type as \code{x} with mis-spelled labels cleaned.
@@ -38,8 +41,12 @@ a data wordlist can be imported from a data frame.
 
 The first column of the wordlist will contain the keys that you want to
 match in your current data set. These are expected to match exactly with
-the exception of two reserved keywords that both start with a full stop:
+the exception of three reserved keywords that start with a full stop:
 \itemize{
+\item \code{.regex [pattern]}: will replace anything matching \code{[pattern]}. \strong{This
+is executed before any other replacements are made}. The \code{[pattern]}
+should be an unquoted, valid, PERL-flavored regular expression. Any
+whitespace padding the regular expression is discarded.
 \item \code{.missing}: replaces any missing values (see NOTE)
 \item \code{.default}: replaces \strong{ALL} values that are not defined in the wordlist
 and are not missing.
@@ -63,7 +70,8 @@ between explicit and implicit missing data.
 \note{
 If there are any missing values in the first column (keys), then they
 are automatically converted to the character "NA" with a warning. If you want
-to target missing data with your wordlist, use the \code{.missing} keyword.
+to target missing data with your wordlist, use the \code{.missing} keyword. The
+\code{.regex} keyword uses \code{\link[=gsub]{gsub()}} with the \code{perl = TRUE} option for replacement.
 }
 \examples{
 
@@ -79,6 +87,13 @@ my_data <- c(letters[1:5], sample(corrections$bad[-5], 10, replace = TRUE))
 my_data[sample(6:15, 2)] <- NA  # with missing elements
 
 clean_spelling(my_data, corrections)
+
+# You can use regular expressions to simplify your list
+corrections <- data.frame(
+  bad =  c(".regex f[ou][^m].+?r$", "unknown", ".missing"), 
+  good = c("foobar",                ".na",     "missing"),
+  stringsAsFactors = FALSE
+)
 
 # You can also set a default value
 corrections_with_default <- rbind(corrections, c(bad = ".default", good = "unknown"))
@@ -97,11 +112,14 @@ clean_spelling(letters, corrections)
 # The can be used for translating survey output
 
 words <- data.frame(
-  option_code = c("Y", "N", "U", ".missing"),
+  option_code = c(".regex ^[yY][eE]?[sS]?", 
+                  ".regex ^[nN][oO]?", 
+                  ".regex ^[uU][nN]?[kK]?", 
+                  ".missing"),
   option_name = c("Yes", "No", ".na", "Missing"),
   stringsAsFactors = FALSE
 )
-clean_spelling(c("Y", "Y", NA, "N", "U", "U", "N"), words)
+clean_spelling(c("Y", "Y", NA, "No", "U", "UNK", "N"), words)
 
 }
 \seealso{

--- a/tests/testthat/test-clean_spelling.R
+++ b/tests/testthat/test-clean_spelling.R
@@ -34,13 +34,20 @@ test_that("regex is possible", {
   datf <- corrections
   datf <- datf[2:5, ]
   # replace foobar, foubar, foobr, fubar, etc with foobar
-  datf$bad[1]  <- ".regex ^f[ou][^m].+r$"
+  datf$bad[1]  <- ".regex f[ou][^m][a-z]+r"
   datf$good[1] <- "foobar"
   
   # replace the literal no importa with dang (shouldn't do anything)
   datf$bad[2]  <- ".regex no importa"
   datf$good[2] <- "dang"
-  expect_identical(clean_spelling(my_data, datf), cleaned_data)
+  
+  # with regex anchors
+  expect_identical(clean_spelling(c(my_data, "dang foobr"), datf),
+                   c(cleaned_data, "dang foobr"))
+  
+  # without anchors
+  expect_identical(clean_spelling(c(my_data, "dang foobr fuuuuber"), datf, anchor_regex = FALSE), 
+                   c(cleaned_data, "dang foobar foobar"))
 
 
 })


### PR DESCRIPTION
This adds a default `anchor_regex = TRUE`, which will wrap the regular expressions in `^` and `$` before processing:

``` r
linelist::clean_spelling(c("food", "foo"), data.frame(".regex foo", "bar"))
#> [1] "food" "bar"

linelist::clean_spelling(c("food", "foo"), data.frame(".regex foo", "bar"), anchor_regex = FALSE)
#> [1] "bard" "bar"
```

<sup>Created on 2019-05-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>