### PR TITLE
fix warning in top_values with subset

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: linelist
 Title: Tools to Import and Tidy Case Linelist Data
-Version: 0.0.36.9000
+Version: 0.0.38.9000
 Authors@R: c(person("Thibaut", "Jombart", email = "thibautjombart@gmail.com", role = c("aut", "cre")),
     person("Zhian N.", "Kamvar", email = "zkamvar@gmail.com", role = c("aut")))
 Description: A collection of wrappers for importing case linelist data from usual formats, and tools for cleaning data, detecting dates, and storing meta-information on the content of the resulting data frame.  

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,21 @@
+# linelist 0.0.38.9000
+
+* `top_values()` no longer throws a spurious warning when the levels in the 
+  subset data are identical to the levels in the full data (#96)
+
+# linelist 0.0.37.9000
+
+* `top_values()` gains a new `subset` argument that allows the user to retain
+  the top levels of a subset of a vector. This is particularly useful for
+  retrospective analysis based on current trends (fixes #92 via #94 and #95, 
+  @thibautjombart)
+
 # linelist 0.0.36.9000
 
 * `top_values()` gains the explicit ties.method parameter, which defaults to 
   "first" to fix issue #88 (thanks to @cwhittaker1000 for spotting the issue
   and providing a detailed explanation).
-*  `top_values()` issues a warning if one of the top values had a tied value
+* `top_values()` issues a warning if one of the top values had a tied value
    that was not included. 
 * `top_values()` issues a warning if the user uses a ties.method that is not
    guaranteed to return exactly n top values.

--- a/R/top_values.R
+++ b/R/top_values.R
@@ -7,8 +7,7 @@
 #' input data to define dominant values. Under the hood, this uses
 #' [forcats::fct_lump()] and [forcats::fct_recode()].
 #'
-#' @author Original code by Thibaut Jombart, rewriting using `forecats` by Zhian
-#'   N. Kamvar
+#' @author Thibaut Jombart and Zhian N. Kamvar
 #'
 #' @export
 #'
@@ -133,7 +132,12 @@ top_values.factor <- function(x, n, replacement = "other",
     
     ## find the levels that were dropped in the subset and replace them with other
     other_levels <- setdiff(levels(x), levels(y))
-    out <- forcats::fct_other(x, drop = other_levels, other_level = other)
+
+    if (length(other_levels)) {
+      out <- forcats::fct_other(x, drop = other_levels, other_level = other)
+    } else {
+      out <- x
+    }
     
     return(out)
   }

--- a/man/top_values.Rd
+++ b/man/top_values.Rd
@@ -97,6 +97,5 @@ top_values(x, n = 1, subset = -1)
 top_values(x, n = 1, subset = -1, ties_method = "last")
 }
 \author{
-Original code by Thibaut Jombart, rewriting using \code{forecats} by Zhian
-N. Kamvar
+Thibaut Jombart and Zhian N. Kamvar
 }

--- a/tests/testthat/test_top_values.R
+++ b/tests/testthat/test_top_values.R
@@ -200,6 +200,12 @@ test_that("top_values() with subsetting", {
   
 })
 
+test_that("top_values() will not return a warning if there is nothing to label as other", {
+
+ ## see https://github.com/reconhub/linelist/issues/96
+ expect_failure(expect_warning(top_values(c("b", "b", "b"), n = 1, subset = c(FALSE, TRUE, TRUE))))
+
+})
 
 
 test_that("top_values() works with ghost levels", {


### PR DESCRIPTION
This will fix #96 

``` r
# remotes::install_github("reconhub/linelist#97")
library("linelist")
x <- c("b", "b", "b")
x_subset <- c(FALSE, TRUE, TRUE)
top_values(x = x, n = 1, subset = x_subset)
#> [1] "b" "b" "b"
```

<sup>Created on 2019-10-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>