### PR TITLE
Add warning for duplicated cleaned variable names

### DIFF
--- a/R/clean_variable_names.R
+++ b/R/clean_variable_names.R
@@ -41,13 +41,63 @@
 #' clean_data
 
 clean_variable_names <- function(x, protect = FALSE, ...) {
-  variable_names <- colnames(x)
+
+  variable_names <- new_names <- colnames(x)
+
   if (is.null(variable_names)) {
     stop('x has no column names')
   }
 
-  protect <- i_logical_from_int(protect, variable_names)
-  colnames(x)[!protect] <- epitrix::clean_labels(variable_names[!protect], ...)
+  # converting only the unprotected varaibles
+  protect <- i_logical_from_int(protect, new_names)
+  new_names[!protect] <- epitrix::clean_labels(new_names[!protect], ...)
+
+  # checking the variables and ammending them with numbers if they end up being
+  # the same
+  .dots     <- list(...)
+  sep       <- if (is.null(.dots[["sep"]])) "_" else .dots[["sep"]]
+
+  # Step 1: rearrange the vars so that protected are first (but if nothing is
+  # protected, then we create dummy subset variables
+  # Step 2: make things unique
+  # Step 3: rearrange things in the correct order
+  # Step 3: check if anything has changed
+  # Step 4: apply the suffixes to the new vector 
+
+  if (length(protect) > 1) {
+    protect_first <- c(which(protect), which(!protect))
+    in_order      <- order(protect_first)
+  } else {
+    protect_first <- in_order <- TRUE
+  }
+
+  var_names <- make.unique(new_names[protect_first], sep = sep)
+  var_names <- var_names[in_order]
+
+  var_names[protect] <- new_names[protect]
+  
+  if (!identical(var_names, new_names)) {
+    # If we get here, then that means some of the data had to be corrected
+    pat <- paste0("[", sep, "]\\d+$") 
+    dupes <- var_names != new_names & grepl(pat, var_names, perl = TRUE)
+    suffix <- sub(paste0("^.+(", pat, ")"), "\\1", var_names[dupes], perl = TRUE)
+    new_names[dupes] <- paste0(new_names[dupes], suffix)
+
+    varn <- format(variable_names[dupes])
+    newn <- format(new_names[dupes])
+    renames <- paste(varn, newn, 
+                     sep = " -> ",
+                     collapse = "\n  ")
+    
+    wrn <- paste("Some variable names were duplicated after cleaning and had",
+                 "suffixes attached:\n\n ",
+                 renames)
+    warning(wrn, call. = FALSE)
+    
+  } 
+
+  colnames(x) <- new_names
+
   # preserving the original variable names in a comment
   names(variable_names) <- colnames(x)
   comment(x) <- c(comment(x), variable_names)

--- a/tests/testthat/test-clean_data.R
+++ b/tests/testthat/test-clean_data.R
@@ -42,6 +42,32 @@ expected_colnames <- c("id", "date_of_onset", "discharge", "gender",
                        "time_of_discharge", "location")
 expected_comment <- setNames(names(md), expected_colnames)
 
+test_that("clean_data() will add suffixes to duplicated column names", {
+                       
+  iris2 <- iris
+  iris2$sepal.width <- iris$Sepal.Width
+  expect_warning(res <- clean_data(iris2), 
+                 "  sepal.width -> sepal_width_1",
+                 fixed = TRUE)
+  expect_named(res, c("sepal_length", "sepal_width", "petal_length",
+                      "petal_width", "species", "sepal_width_1"))
+
+})
+
+test_that("clean_data() will respect protected columns when cleaning names", {
+
+  iris2 <- iris
+  iris2$sepal_width <- iris$Sepal.Width
+  expect_warning(res <- clean_data(iris2, protect = which(names(iris2) == "sepal_width")), 
+                 "  Sepal.Width -> sepal_width_1",
+                 fixed = TRUE)
+  expect_named(res, c("sepal_length", "sepal_width_1", "petal_length",
+                      "petal_width", "species", "sepal_width"))
+
+})
+
+
+
 test_that("clean_data() needs a data frame with columns and/or rows", {
   expect_error(clean_data(DAT), "DAT is not a data frame")
   expect_error(clean_data(data.frame()), "data.frame\\(\\) has no columns")


### PR DESCRIPTION
This will fix #100 by adding a warning and modifying the variable names so that they work.

``` r
library("linelist")
iris$sepal.width <- iris$Sepal.Width
head(clean_data(iris))
#> Warning: Some variable names were duplicated after cleaning and had suffixes attached:
#> 
#>   sepal.width -> sepal_width_1
#>   sepal_length sepal_width petal_length petal_width species sepal_width_1
#> 1          5.1         3.5          1.4         0.2  setosa           3.5
#> 2          4.9         3.0          1.4         0.2  setosa           3.0
#> 3          4.7         3.2          1.3         0.2  setosa           3.2
#> 4          4.6         3.1          1.5         0.2  setosa           3.1
#> 5          5.0         3.6          1.4         0.2  setosa           3.6
#> 6          5.4         3.9          1.7         0.4  setosa           3.9
```

<sup>Created on 2019-10-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>


This will also respect protected variable names (notice that the first sepal_width is changed):

``` r
library("linelist")
iris$sepal_width <- iris$Sepal.Width
head(clean_data(iris, protect = which(names(iris) == "sepal_width")))
#> Warning: Some variable names were duplicated after cleaning and had suffixes attached:
#> 
#>   Sepal.Width -> sepal_width_1
#>   sepal_length sepal_width_1 petal_length petal_width species sepal_width
#> 1          5.1           3.5          1.4         0.2  setosa         3.5
#> 2          4.9           3.0          1.4         0.2  setosa         3.0
#> 3          4.7           3.2          1.3         0.2  setosa         3.2
#> 4          4.6           3.1          1.5         0.2  setosa         3.1
#> 5          5.0           3.6          1.4         0.2  setosa         3.6
#> 6          5.4           3.9          1.7         0.4  setosa         3.9
```

<sup>Created on 2019-10-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>


You can install and test this out via:

```r
remotes::install_github("reconub/linelist#101")
```
